### PR TITLE
Add a Metrics object to ApplicationConfig

### DIFF
--- a/Assets/Resources/ApplicationConfig.json
+++ b/Assets/Resources/ApplicationConfig.json
@@ -1,19 +1,22 @@
 {
-	"Version": "0.1.11",
-	"Log": {
-		"Level": "Error"
-	},
-	"Network": {
-		"ApiVersion": "0.0.1",
-		"Current": "cloud",
-		"AllEnvironments": [
-			{
-				"Name": "cloud",
-				"TrellisUrl": "https://trellis.enklu.com:10001/v1",
-				"AssetsUrl": "https://s3-us-west-2.amazonaws.com:443/axatmtcyltmxltqzltmw.assets.bundles/",
-				"BundlesUrl": "https://s3-us-west-2.amazonaws.com:443/axatmtcyltmxltqzltmw.assets.bundles/",
-				"ThumbsUrl": "https://s3-us-west-2.amazonaws.com:443/axatmtcyltmxltqzltmw.assets.thumbs/"
-			}
-		]
-	}
+    "Version": "0.1.11",
+    "Log": {
+        "Level": "Error"
+    },
+    "Network": {
+        "ApiVersion": "0.0.1",
+        "Current": "cloud",
+        "AllEnvironments": [
+            {
+                "Name": "cloud",
+                "TrellisUrl": "https://trellis.enklu.com:10001/v1",
+                "AssetsUrl": "https://s3-us-west-2.amazonaws.com:443/axatmtcyltmxltqzltmw.assets.bundles/",
+                "BundlesUrl": "https://s3-us-west-2.amazonaws.com:443/axatmtcyltmxltqzltmw.assets.bundles/",
+                "ThumbsUrl": "https://s3-us-west-2.amazonaws.com:443/axatmtcyltmxltqzltmw.assets.thumbs/"
+            }
+        ]
+    },
+    "Metrics": {
+        "Enabled": false
+    }
 }

--- a/Assets/Source/Application/ApplicationConfig.cs
+++ b/Assets/Source/Application/ApplicationConfig.cs
@@ -522,6 +522,11 @@ namespace CreateAR.EnkluPlayer
     public class MetricsConfig
     {
         /// <summary>
+        /// Whether metrics should be enabled or not.
+        /// </summary>
+        public bool Enabled = true;
+
+        /// <summary>
         /// Hostname of the metrics box.
         /// </summary>
         public string Hostname;
@@ -537,6 +542,8 @@ namespace CreateAR.EnkluPlayer
         /// <param name="config">The config.</param>
         public void Override(MetricsConfig config)
         {
+            Enabled = config.Enabled;
+
             if (!string.IsNullOrEmpty(config.Hostname))
             {
                 Hostname = config.Hostname;

--- a/Assets/Source/Main.cs
+++ b/Assets/Source/Main.cs
@@ -148,7 +148,7 @@ namespace CreateAR.EnkluPlayer
             // start metrics
             var config = _binder.GetInstance<ApplicationConfig>().Metrics;
             var metrics = _binder.GetInstance<IMetricsService>();
-            if (!UnityEngine.Application.isEditor)
+            if (config.Enabled && !UnityEngine.Application.isEditor)
             {
 #if !UNITY_WEBGL
                 metrics.AddTarget(new HostedGraphiteMetricsTarget(


### PR DESCRIPTION
Also added support for disabling Metrics thru config (enabled by default). Changed some line endings to LF as well.

This slightly breaks the optional nature of configuration when using an override. It'd be possible in the override config to supply a metrics object without specifying `Enabled`, and since it's a bool it'd default to the class' default (true). It seemed kind of gross to use a string or an int to enable the null/unknown state. But defaulting to true doesn't seem so bad- if you're overriding the config, you probably want to enable it to true anyways unless you're explicitly setting it to false when the non-override version eventually changes.