### PR TITLE
EK-413 Proximity RTE spam

### DIFF
--- a/Assets/Source/Player/IUX/Element/Element.cs
+++ b/Assets/Source/Player/IUX/Element/Element.cs
@@ -212,6 +212,11 @@ namespace CreateAR.EnkluPlayer.IUX
         /// </summary>
         public void Destroy()
         {
+            if (OnDestroyed != null) {
+                OnDestroyed(this);
+                OnDestroyed = null;
+            }
+
             UnloadInternalBeforeChildren();
 
             // destroy children
@@ -226,12 +231,6 @@ namespace CreateAR.EnkluPlayer.IUX
 
             UnloadInternalAfterChildren();
             DestroyInternal();
-
-            if (OnDestroyed != null)
-            {
-                OnDestroyed(this);
-                OnDestroyed = null;
-            }
         }
 
         /// <summary>

--- a/Assets/Source/Player/IUX/Element/Element.cs
+++ b/Assets/Source/Player/IUX/Element/Element.cs
@@ -212,7 +212,8 @@ namespace CreateAR.EnkluPlayer.IUX
         /// </summary>
         public void Destroy()
         {
-            if (OnDestroyed != null) {
+            if (OnDestroyed != null)
+            {
                 OnDestroyed(this);
                 OnDestroyed = null;
             }

--- a/Assets/Source/Player/Scripting/Interop/ProximityManager.cs
+++ b/Assets/Source/Player/Scripting/Interop/ProximityManager.cs
@@ -266,6 +266,8 @@ namespace CreateAR.EnkluPlayer.Scripting
                 element.Schema.Get<bool>(PROP_PROXIMITY_TRIGGER).OnChanged -= triggerChange;
                 element.Schema.Get<float>(PROP_PROXIMITY_INNER).OnChanged -= radiusChange;
                 element.Schema.Get<float>(PROP_PROXIMITY_OUTER).OnChanged -= radiusChange;
+
+                RemoveElement(elementjs);
             };
 
             // Trigger initial update.
@@ -289,6 +291,15 @@ namespace CreateAR.EnkluPlayer.Scripting
                     element.schema.getOwnNumber(PROP_PROXIMITY_INNER),
                     element.schema.getOwnNumber(PROP_PROXIMITY_OUTER));
             }
+        }
+
+        /// <summary>
+        /// Configure the ProximityChecker to remove tracking for an ElementJs instance.
+        /// </summary>
+        /// <param name="element"></param>
+        private void RemoveElement(ElementJs element)
+        {
+            _proximityChecker.SetElementState(element, false, false);
         }
 
         /// <summary>


### PR DESCRIPTION
When exiting an experience or entering edit mode, if the proximity js api had been used the runtime would be spammed with null refs and become unbearably slow.

Two issues:
1. ProximityManager unsubscribed from schema changes on Element destruction, but never updated ProximityChecker to remove tracking.
- ProximityManager now has a `RemoveElement` method that gets called on Element destruction.

2. Since ProximityChecker now uses GameObjects, OnDestroyed would be invoked after Widget instances already removed their GameObject reference, and not be able to remove tracking properly.
- Element invokes `OnDestroyed` before calling its internal unload methods. This seems like a good change so that anything relying on an Element's state can cleanup properly before the Element starts cleaning itself up. The current usage of `OnDestroyed`s seems safe to change its order as well.