### PR TITLE
Schema changes don't invoke watchers if the value was the same

### DIFF
--- a/Assets/Source/Player/IUX/Element/ElementSchemaProp.cs
+++ b/Assets/Source/Player/IUX/Element/ElementSchemaProp.cs
@@ -73,6 +73,17 @@ namespace CreateAR.EnkluPlayer.IUX
             }
             set
             {
+                // Early out if the same value is being set
+                if (_value == null && value == null)
+                {
+                    return;
+                }
+
+                if (_value != null && _value.Equals(value))
+                {
+                    return;
+                }
+
                 // break connection
                 if (null != _parent)
                 {


### PR DESCRIPTION
When playing with some things today I realized there were some duplicate invokes going out. Probably more common with the web builds than a holo build since there's the update messages & preview messages, but this doesn't seem like a bad check to have in place?

I used this change with all of my normal work today and didn't run into any bugs, but haven't done any exhaustive testing by any means.