### PR TITLE
ScreenWidget smoothing

### DIFF
--- a/Assets/Editor/Test/Scripting/VecJsApi_Tests.cs
+++ b/Assets/Editor/Test/Scripting/VecJsApi_Tests.cs
@@ -90,6 +90,22 @@ namespace CreateAR.EnkluPlayer.Test.Scripting
             
             Assert.IsTrue(result < Mathf.Epsilon);
         }
+
+        [Test]
+        public void Vec3Angle()
+        {
+            var result = (float) _engine.Run(@"v.angle(v.right, v.up);").AsNumber();
+            var unityAngle = Vector3.Angle(Vector3.right, Vector3.up);
+            Assert.IsTrue(Mathf.Abs(result - unityAngle) < Mathf.Epsilon);
+
+            result = (float) _engine.Run(@"v.angle(v.up, v.up);").AsNumber();
+            unityAngle = Vector3.Angle(Vector3.up, Vector3.up);
+            Assert.IsTrue(Mathf.Abs(result - unityAngle) < Mathf.Epsilon);
+
+            result = (float) _engine.Run(@"v.angle(v.right, vec3(-1, 0, 0));").AsNumber();
+            unityAngle = Vector3.Angle(Vector3.right, Vector3.left);
+            Assert.IsTrue(Mathf.Abs(result - unityAngle) < Mathf.Epsilon);
+        }
         
         [Test]
         public void Vec3Len()

--- a/Assets/Source/Math/Vec3.cs
+++ b/Assets/Source/Math/Vec3.cs
@@ -8,6 +8,9 @@ namespace CreateAR.EnkluPlayer
     [Serializable]
     public struct Vec3
     {
+        /// <summary>
+        /// Radians -> Degrees.
+        /// </summary>
         private const float RAD2_DEG = (float) (360 / (2 * Math.PI));
 
         /// <summary>

--- a/Assets/Source/Math/Vec3.cs
+++ b/Assets/Source/Math/Vec3.cs
@@ -8,6 +8,8 @@ namespace CreateAR.EnkluPlayer
     [Serializable]
     public struct Vec3
     {
+        private const float RAD2_DEG = (float) (360 / (2 * Math.PI));
+
         /// <summary>
         /// Default vector.
         /// </summary>
@@ -19,9 +21,19 @@ namespace CreateAR.EnkluPlayer
         public static readonly Vec3 One = new Vec3(1, 1, 1);
 
         /// <summary>
-        /// Identity vector.
+        /// Right vector.
+        /// </summary>
+        public static readonly Vec3 Right = new Vec3(1, 0, 0);
+
+        /// <summary>
+        /// Up vector.
         /// </summary>
         public static readonly Vec3 Up = new Vec3(0, 1, 0);
+
+        /// <summary>
+        /// Forward vector.
+        /// </summary>
+        public static readonly Vec3 Forward = new Vec3(0, 0, 1);
 
         /// <summary>
         /// X component.
@@ -169,8 +181,8 @@ namespace CreateAR.EnkluPlayer
         /// <summary>
         /// Returns the dot product for two vectors.
         /// </summary>
-        /// <param name="lhs">Left hand side of the dot product.</param>
-        /// <param name="rhs">Right hand side of the dot product.</param>
+        /// <param name="lhs">Left hand side of the cross product.</param>
+        /// <param name="rhs">Right hand side of the cross product.</param>
         /// <returns></returns>
         public static Vec3 Cross(Vec3 lhs, Vec3 rhs)
         {
@@ -178,6 +190,17 @@ namespace CreateAR.EnkluPlayer
                 lhs.y*rhs.z - lhs.z*rhs.y,
                 lhs.z*rhs.x - lhs.x*rhs.z,
                 lhs.x*rhs.y - lhs.y*rhs.x);
+        }
+
+        /// <summary>
+        /// Returns the angle between two vectors in degrees.
+        /// </summary>
+        /// <param name="lhs">Left hand side of the angle.</param>
+        /// <param name="rhs">Right hand side of the angle.</param>
+        /// <returns></returns>
+        public static float Angle(Vec3 lhs, Vec3 rhs)
+        {
+            return (float) Math.Acos(Dot(lhs, rhs) / (lhs.Magnitude * rhs.Magnitude)) * RAD2_DEG;
         }
 
         /// <summary>

--- a/Assets/Source/Player/IUX/Element/ElementFactory.cs
+++ b/Assets/Source/Player/IUX/Element/ElementFactory.cs
@@ -259,7 +259,9 @@ namespace CreateAR.EnkluPlayer.IUX
             {
                 Floats = new Dictionary<string, float>
                 {
-                    { "distance", 1.2f }
+                    { "distance", 1.2f },
+                    { "stabilization", 2f },
+                    { "smoothing", 15f }
                 }
             });
         }

--- a/Assets/Source/Player/IUX/Widget/ScreenWidget.cs
+++ b/Assets/Source/Player/IUX/Widget/ScreenWidget.cs
@@ -18,6 +18,41 @@ namespace CreateAR.EnkluPlayer.IUX
         private ElementSchemaProp<float> _distanceProp;
 
         /// <summary>
+        /// How much directional drift to ignore
+        /// </summary>
+        private ElementSchemaProp<float> _stabilizationProp;
+
+        /// <summary>
+        /// How fast (deg/sec) to update the position
+        /// </summary>
+        private ElementSchemaProp<float> _smoothingProp;
+
+        /// <summary>
+        /// A stable position near the intent's direction.
+        /// </summary>
+        private Vec3 _stabilizedForward;
+
+        /// <summary>
+        /// The previous stable position.
+        /// </summary>
+        private Vec3 _lastStableForward;
+
+        /// <summary>
+        /// The current forward, a value between stable & last stable.
+        /// </summary>
+        private Vec3 _interpolatedForward;
+
+        /// <summary>
+        /// The angular distance between stable/last.
+        /// </summary>
+        private float _lerpDist = 0;
+
+        /// <summary>
+        /// The current transition progress between stable/last.
+        /// </summary>
+        private float _lerpAcc = 0;
+
+        /// <summary>
         /// Constructor.
         /// </summary>
         public ScreenWidget(
@@ -29,6 +64,8 @@ namespace CreateAR.EnkluPlayer.IUX
             : base(gameObject, layers, tweens, colors)
         {
             _intention = intention;
+
+            _interpolatedForward = _stabilizedForward = _intention.Forward;
         }
 
         /// <inheritdoc />
@@ -37,6 +74,8 @@ namespace CreateAR.EnkluPlayer.IUX
             base.LoadInternalAfterChildren();
 
             _distanceProp = Schema.GetOwn("distance", 1f);
+            _stabilizationProp = Schema.GetOwn("stabilization", 2f);
+            _smoothingProp = Schema.GetOwn("smoothing", 15f);
         }
 
         /// <inheritdoc />
@@ -44,9 +83,27 @@ namespace CreateAR.EnkluPlayer.IUX
         {
             base.UpdateInternal();
 
-            var pos = _intention.Origin + _distanceProp.Value * _intention.Forward;
+            // Update stabilized forward as needed
+            if (Vec3.Angle(_stabilizedForward, _intention.Forward) > _stabilizationProp.Value)
+            {
+                _lastStableForward = _interpolatedForward;
+                _stabilizedForward = _intention.Forward;
+
+                _lerpDist = Vec3.Angle(_stabilizedForward, _interpolatedForward);
+                _lerpAcc = 0;
+            }
+            
+            // Update the interpolated forward as needed
+            if (_lerpAcc < 1)
+            {
+                var step = (_smoothingProp.Value * Time.deltaTime) / _lerpDist;
+                _lerpAcc = Mathf.Min(1, _lerpAcc + step);
+                _interpolatedForward = Vec3.Lerp(_lastStableForward, _stabilizedForward, _lerpAcc).Normalized;
+            }
+
+            var pos = _intention.Origin + _distanceProp.Value * _interpolatedForward;
             GameObject.transform.position = pos.ToVector();
-            GameObject.transform.forward = _intention.Forward.ToVector();
+            GameObject.transform.forward = _interpolatedForward.ToVector();
         }
     }
 }

--- a/Assets/Source/Player/IUX/Widget/ScreenWidget.cs
+++ b/Assets/Source/Player/IUX/Widget/ScreenWidget.cs
@@ -73,9 +73,9 @@ namespace CreateAR.EnkluPlayer.IUX
         {
             base.LoadInternalAfterChildren();
 
-            _distanceProp = Schema.GetOwn("distance", 1f);
-            _stabilizationProp = Schema.GetOwn("stabilization", 2f);
-            _smoothingProp = Schema.GetOwn("smoothing", 15f);
+            _distanceProp = Schema.Get<float>("distance");
+            _stabilizationProp = Schema.Get<float>("stabilization");
+            _smoothingProp = Schema.Get<float>("smoothing");
         }
 
         /// <inheritdoc />

--- a/Assets/Source/Player/Scripting/Interface/Math/Vec3Methods.cs
+++ b/Assets/Source/Player/Scripting/Interface/Math/Vec3Methods.cs
@@ -68,6 +68,14 @@
         }
 
         /// <summary>
+        /// Angle between two vectors in degrees.
+        /// </summary>
+        public float angle(Vec3 a, Vec3 b)
+        {
+            return Vec3.Angle(a, b);
+        }
+
+        /// <summary>
         /// Vector length.
         /// </summary>
         public float len(Vec3 a)

--- a/docs/element.schema.properties.md
+++ b/docs/element.schema.properties.md
@@ -136,6 +136,8 @@ Inherits all `Menu` properties.
 | Property Name | Type  | Default | Description                                                  | Inherit |
 | ------------- | ----- | ------- | ------------------------------------------------------------ | ------- |
 | distance      | float | 1       | Determines how far away from the camera the element will be locked. | No      |
+| stabilization | float | 2       | The angular drift (in degrees) to ignore before moving the screen.  | No      |
+| smoothing     | float | 15      | The rate the screen will move (degrees/second).                     | No      |
 
 #### Slider
 


### PR DESCRIPTION
When using a ScreenWidget for a "try and use a gesture!" screen (or anything that might hang around for a bit), the jitter from slight head movements is pretty noticeable. To try and make this UX a bit better, I added some schema to control if/how a ScreenWidget should reposition itself.

It isn't perfect, and despite having some frame rate independence, it can be jerky at times if there's a lot going on in the scene. But, playing with the values a bit, the results seem good in my extremely biased opinion.

Before:
![screenbefore](https://user-images.githubusercontent.com/4741738/46052719-6ee73700-c0f4-11e8-9f2b-c57b80be1cc8.gif)

After:
![screenafter](https://user-images.githubusercontent.com/4741738/46052745-8c1c0580-c0f4-11e8-9ea9-201838333366.gif)