### PR TITLE
Rotation maths - part 1

### DIFF
--- a/Assets/Editor/Test/Scripting/TestData.cs
+++ b/Assets/Editor/Test/Scripting/TestData.cs
@@ -1,0 +1,37 @@
+﻿namespace CreateAR.EnkluPlayer.Test.Scripting
+{
+    public static class TestData
+    {
+        // A handful of rotations from different axes/quadrants
+        public static Vec3[] EulerArray =
+        {
+            new Vec3( 0,     0,     0),
+            new Vec3( 90,    0,    0),
+            new Vec3( 180,    0,    0),
+            new Vec3( 270,    0,    0),
+
+            new Vec3( 0,    0,    45),
+            new Vec3( 0,    45,   0),
+            new Vec3( 45,   0,    0),
+            new Vec3( 0,    0,   -45),
+            new Vec3( 0,   -45,   0),
+            new Vec3(-45,   0,    0),
+            new Vec3( 30,   60,   20),
+            new Vec3( 30,   60,  -20),
+            new Vec3( 30,  -60,   20),
+            new Vec3( 30,  -60,  -20),
+            new Vec3(-30,   60,   20),
+            new Vec3(-30,   60,  -20),
+            new Vec3(-30,  -60,   20),
+            new Vec3(-30,  -60,  -20),
+            new Vec3( 120,  160,  140),
+            new Vec3( 120,  160, -140),
+            new Vec3( 120, -160,  140),
+            new Vec3( 120, -160, -140),
+            new Vec3(-120,  160,  140),
+            new Vec3(-120,  160, -140),
+            new Vec3(-120, -160,  140),
+            new Vec3(-120, -160, -140),
+        };
+    }
+}

--- a/Assets/Editor/Test/Scripting/TestData.cs.meta
+++ b/Assets/Editor/Test/Scripting/TestData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1239d9e44a16b0447be3cb8da3b39303
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/Test/Scripting/TransformJsApi_Tests.cs
+++ b/Assets/Editor/Test/Scripting/TransformJsApi_Tests.cs
@@ -1,0 +1,43 @@
+﻿using CreateAR.EnkluPlayer.IUX;
+using CreateAR.EnkluPlayer.Scripting;
+using Jint;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace CreateAR.EnkluPlayer.Test.Scripting
+{
+    [TestFixture]
+    public class TransformJsApi_Tests
+    {
+        private Engine _engine;
+        private ElementJs _element;
+        private GameObject _gameObject;
+
+        [SetUp]
+        public void Setup()
+        {
+            _engine = new Engine();
+            _element = new ElementJs(null, null, _engine, new Element());
+            _engine.SetValue("this", _element);
+
+            _gameObject = new GameObject("TransformJsApi Tests");
+        }
+
+        [Test]
+        public void Forward()
+        {
+            // Test that our forward matches Unity's over a variety of euler rotations
+            for (int i = 0; i < TestData.EulerArray.Length; i++)
+            {
+                var euler = TestData.EulerArray[i];
+                _element.transform.rotation = Quat.Euler(euler);
+                _gameObject.transform.rotation = Quaternion.Euler(euler.ToVector());
+
+                // Why does this require this.this?!
+                var enkluForward = _engine.Run<Vec3>("this.this.transform.forward");
+                var unityForward = _gameObject.transform.forward;
+                Assert.IsTrue(Vector3.Angle(enkluForward.ToVector(), unityForward) < Mathf.Epsilon);
+            }
+        }
+    }
+}

--- a/Assets/Editor/Test/Scripting/TransformJsApi_Tests.cs.meta
+++ b/Assets/Editor/Test/Scripting/TransformJsApi_Tests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 67309fb3bc87c2a44b4c2ac554e1b821
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Source/Math/Quat.cs
+++ b/Assets/Source/Math/Quat.cs
@@ -99,29 +99,62 @@ namespace CreateAR.EnkluPlayer
         /// <summary>
         /// Create a Quat from Euler angles.
         /// 
-        /// From: http://www.euclideanspace.com/maths/geometry/rotations/conversions/eulerToQuaternion/index.htm
+        /// References: http://www.euclideanspace.com/maths/geometry/rotations/conversions/eulerToQuaternion/index.htm
+        ///           : https://stackoverflow.com/questions/11492299/quaternion-to-euler-angles-algorithm-how-to-convert-to-y-up-and-between-ha
+        /// Notes: Adapted from references. They are in radians
+        /// and have mixed coordinate systems / x, y, z, w order
         /// </summary>
-        /// <param name="euler">The euler angles in querstion.</param>
+        /// <param name="euler">The euler angles in question.</param>
         /// <returns></returns>
         public static Quat Euler(Vec3 euler)
         {
-            var c1 = Math.Cos(euler.x / 2.0);
-            var s1 = Math.Sin(euler.x / 2.0);
-            
-            var c2 = Math.Cos(euler.y / 2.0);
-            var s2 = Math.Sin(euler.y / 2.0);
-            
-            var c3 = Math.Cos(euler.z / 2.0);
-            var s3 = Math.Sin(euler.z / 2.0);
-            
-            var c1c2 = c1 * c2;
-            var s1s2 = s1 * s2;
-            
+            var radians = (float) Math.PI / 180 * euler;
+
+            // Yaw
+            var sy = (float) Math.Sin(radians.x / 2);
+            var cy = (float) Math.Cos(radians.x / 2);
+
+            // Pitch
+            var sp = (float) Math.Sin(radians.y / 2);
+            var cp = (float) Math.Cos(radians.y / 2);
+
+            // Roll
+            var sr = (float) Math.Sin(radians.z / 2);
+            var cr = (float) Math.Cos(radians.z / 2);
+
             return new Quat(
-                (float) (c1c2 * c3 - s1s2 * s3),
-                (float) (c1c2 * s3 + s1s2 * c3),
-                (float) (s1 * c2 * c3 + c1 * s2 * s3),
-                (float) (c1 * s2 * c3 - s1 * c2 * s3));
+                sy * cp * cr + cy * sp * sr,
+                cy * sp * cr - sy * cp * sr,
+                cy * cp * sr - sy * sp * cr,
+                cy * cp * cr + sy * sp * sr
+            );
+        }
+
+        /// <summary>
+        /// Multiples a Vec3 by a Quat.
+        ///
+        /// References: http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/transforms/derivations/vectors/index.htm
+        /// </summary>
+        /// <param name="rotation"></param>
+        /// <param name="forward"></param>
+        /// <returns></returns>
+        public static Vec3 Mult(Quat rotation, Vec3 forward)
+        {
+            var xSq2 = rotation.x * rotation.x * 2f;
+            var ySq2 = rotation.y * rotation.y * 2f;
+            var zSq2 = rotation.z * rotation.z * 2f;
+            var xy2 = rotation.x * rotation.y * 2f;
+            var xz2 = rotation.x * rotation.z * 2f;
+            var yz2 = rotation.y * rotation.z * 2f;
+            var wx2 = rotation.w * rotation.x * 2f;
+            var wy2 = rotation.w * rotation.y * 2f;
+            var wz2 = rotation.w * rotation.z * 2f;
+            
+            return new Vec3(
+                (float) ((1.0 - (ySq2 + zSq2)) * forward.x + (xy2 - wz2) * forward.y + (xz2 + wy2) * forward.z),
+                (float) ((xy2 + wz2) * forward.x + (1.0 - (xSq2 + zSq2)) * forward.y + (yz2 - wx2) * forward.z),
+                (float) ((xz2 - wy2) * forward.x + (yz2 + wx2) * forward.y + (1.0 - (xSq2 + ySq2)) * forward.z)
+            );
         }
 
         /// <summary>

--- a/Assets/Source/Math/Quat.cs
+++ b/Assets/Source/Math/Quat.cs
@@ -162,7 +162,7 @@ namespace CreateAR.EnkluPlayer
         /// </summary>
         public static Quat Identity
         {
-            get { return new Quat(1, 1, 1, 1); }
+            get { return new Quat(0, 0, 0, 1); }
         }
 
         /// <summary>

--- a/Assets/Source/Player/Scripting/Interface/Elements/ElementTransformJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/ElementTransformJsApi.cs
@@ -54,6 +54,11 @@ namespace CreateAR.EnkluPlayer.Scripting
             set { _scaleProp.Value = value; }
         }
 
+        public Vec3 forward
+        {
+            get { return Quat.Mult(rotation, Vec3.Forward); }
+        }
+
         /// <summary>
         /// Constructor.
         /// </summary>

--- a/Assets/Source/Player/Scripting/Interface/Math/QuatMethods.cs
+++ b/Assets/Source/Player/Scripting/Interface/Math/QuatMethods.cs
@@ -1,6 +1,4 @@
-﻿using UnityEngine;
-
-namespace CreateAR.EnkluPlayer
+﻿namespace CreateAR.EnkluPlayer
 {
     /// <summary>
     /// Quaternion methods.
@@ -15,7 +13,7 @@ namespace CreateAR.EnkluPlayer
         /// <summary>
         /// Identity rotation.
         /// </summary>
-        public readonly Quat identity = Quaternion.identity.ToQuat();
+        public readonly Quat identity = Quat.Identity;
 
         /// <summary>
         /// Creates a new Quat.
@@ -30,7 +28,7 @@ namespace CreateAR.EnkluPlayer
         /// </summary>
         public Quat euler(float x, float y, float z)
         {
-            return Quaternion.Euler(x, y, z).ToQuat();
+            return Quat.Euler(x, y, z);
         }
 
         /// <summary>
@@ -38,7 +36,7 @@ namespace CreateAR.EnkluPlayer
         /// </summary>
         public Quat eul(float x, float y, float z)
         {
-            return Quaternion.Euler(x, y, z).ToQuat();
+            return Quat.Euler(x, y, z);
         }
     }
 }


### PR DESCRIPTION
Who knows how many parts this will be, but I might as well get what I have up now and add more as I go.

I started with making a `transform.forward` to be available for scripting, which then led to a discovery that Quat.Euler wasn't really used by much and didn't match Unity's euler -> quaternion conversions. So that's fixed! In addition to this, I changed Quat.Identity to match Unity's Quaternion identity.