### PR TITLE
EK-451 Activator Buffers

### DIFF
--- a/Assets/Prefabs/Config/Widget.prefab
+++ b/Assets/Prefabs/Config/Widget.prefab
@@ -204,6 +204,7 @@ MonoBehaviour:
     - {fileID: 21300000, guid: ad79995fcc28f4142b41973b07b6c55e, type: 3}
     - {fileID: 21300000, guid: f63699ec041c5de45bdf8a5f4b9f8c3a, type: 3}
     - {fileID: 21300000, guid: 31058c9c367bc7c4b96107318a88745e, type: 3}
+  AimBufferFactor: 3
   AimFeedbackColor:
     serializedVersion: 2
     key0: {r: 1, g: 1, b: 1, a: 0}

--- a/Assets/Source/Player/IUX/Activator/ActivatorActivatedState.cs
+++ b/Assets/Source/Player/IUX/Activator/ActivatorActivatedState.cs
@@ -64,9 +64,9 @@ namespace CreateAR.EnkluPlayer.IUX
         {
             base.Update(deltaTime);
 
-            if (!_activator.Focused)
+            if (_activator.Aim < 0)
             {
-                _activator.Ready();
+                _activator.Imminent();
             }
         }
 

--- a/Assets/Source/Player/IUX/Activator/ActivatorActivatingState.cs
+++ b/Assets/Source/Player/IUX/Activator/ActivatorActivatingState.cs
@@ -77,9 +77,9 @@ namespace CreateAR.EnkluPlayer.IUX
         /// <param name="deltaTime"></param>
         public override void Update(float deltaTime)
         {
-            if (!_activator.Focused)
+            if (_activator.Aim < 0)
             {
-                _activator.Ready();
+                _activator.Imminent();
                 return;
             }
 

--- a/Assets/Source/Player/IUX/Activator/ActivatorImminentState.cs
+++ b/Assets/Source/Player/IUX/Activator/ActivatorImminentState.cs
@@ -1,0 +1,74 @@
+﻿namespace CreateAR.EnkluPlayer.IUX
+{
+    /// <summary>
+    /// State the button takes when the user might activate it soon.
+    /// </summary>
+    public class ActivatorImminentState : ActivatorState
+    {
+        /// <summary>
+        /// Configuration for widgets.
+        /// </summary>
+        private readonly WidgetConfig _config;
+
+        /// <summary>
+        /// Activator.
+        /// </summary>
+        private readonly ActivatorPrimitive _activator;
+
+        /// <summary>
+        /// Activation as the state is entered.
+        /// </summary>
+        private float _initialActivation;
+
+        /// <summary>
+        /// Elapsed time in the state.
+        /// </summary>
+        private float _elapsed;
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="config">Configuration for widgets.</param>
+        /// <param name="activator">Activator.</param>
+        /// <param name="schema">Schema to use.</param>
+        public ActivatorImminentState(
+            WidgetConfig config,
+            ActivatorPrimitive activator,
+            ElementSchema schema)
+            : base(
+                schema.Get<string>("ready.color"),
+                schema.Get<string>("ready.color"),
+                schema.Get<float>("ready.frameScale"))
+        {
+            _config = config;
+            _activator = activator;
+        }
+
+        /// <inheritdoc />
+        public override void Enter(object context)
+        {
+            _elapsed = 0.0f;
+            _initialActivation = _activator.Activation;
+        }
+
+        /// <inheritdoc />
+        public override void Update(float deltaTime)
+        {
+            if (!_activator.Focused)
+            {
+                _activator.Ready();
+            }
+            else if (_activator.Aim >= 0)
+            {
+                _activator.Activating();
+            }
+            else
+            {
+                _elapsed += deltaTime;
+
+                // recede the activation percentage over time
+                _activator.Activation = _initialActivation * _config.GetFillDelay(_elapsed);
+            }
+        }
+    }
+}

--- a/Assets/Source/Player/IUX/Activator/ActivatorImminentState.cs.meta
+++ b/Assets/Source/Player/IUX/Activator/ActivatorImminentState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1136024be4fb7d24f9e9a8f2ec63162f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Source/Player/IUX/Activator/ActivatorPrimitive.cs
+++ b/Assets/Source/Player/IUX/Activator/ActivatorPrimitive.cs
@@ -112,6 +112,10 @@ namespace CreateAR.EnkluPlayer.IUX
                 }
                 else
                 {
+                    // Reset to ready state, this element might have been
+                    //  overlapped by another and not transitioned back.
+                    Ready();
+
                     _messages.Publish(
                         MessageTypes.WIDGET_UNFOCUS,
                         new WidgetUnfocusEvent(_target));

--- a/Assets/Source/Player/IUX/Activator/ActivatorPrimitive.cs
+++ b/Assets/Source/Player/IUX/Activator/ActivatorPrimitive.cs
@@ -259,16 +259,26 @@ namespace CreateAR.EnkluPlayer.IUX
         /// <inheritdoc cref="IRaycaster"/>
         public bool Raycast(Vec3 origin, Vec3 direction)
         {
+            Vec3 hitPosition, colliderCenter;
+            return Raycast(origin, direction, out hitPosition, out colliderCenter);
+        }
+
+        public bool Raycast(Vec3 origin, Vec3 direction, out Vec3 hitPosition, out Vec3 colliderCenter)
+        {
             if (_renderer.FocusCollider != null)
             {
                 var ray = new Ray(origin.ToVector(), direction.ToVector());
                 RaycastHit hitInfo;
                 if (_renderer.FocusCollider.Raycast(ray, out hitInfo, float.PositiveInfinity))
                 {
+                    hitPosition = hitInfo.point.ToVec();
+                    colliderCenter = hitInfo.collider.bounds.center.ToVec();
                     return true;
                 }
             }
 
+            hitPosition = Vec3.Zero;
+            colliderCenter = Vec3.Zero;
             return false;
         }
 

--- a/Assets/Source/Player/IUX/Activator/ActivatorPrimitive.cs
+++ b/Assets/Source/Player/IUX/Activator/ActivatorPrimitive.cs
@@ -363,6 +363,19 @@ namespace CreateAR.EnkluPlayer.IUX
         }
 
         /// <summary>
+        /// Moves into imminent state.
+        /// </summary>
+        public void Imminent()
+        {
+            _states.Change<ActivatorImminentState>();
+
+            if (null != OnStateChanged)
+            {
+                OnStateChanged((ActivatorState) _states.Current);
+            }
+        }
+
+        /// <summary>
         /// Moves into activating state.
         /// </summary>
         public void Activating()
@@ -433,7 +446,8 @@ namespace CreateAR.EnkluPlayer.IUX
             {
                 _states = new FiniteStateMachine(new IState[]
                 {
-                    new ActivatorReadyState(_config, this, Schema),
+                    new ActivatorReadyState(this, Schema),
+                    new ActivatorImminentState(_config, this, Schema), 
                     new ActivatorActivatingState(_config, this, _intention, Schema, true),
                     new ActivatorActivatedState(_target, this, _messages, Schema)
                 });

--- a/Assets/Source/Player/IUX/Activator/ActivatorReadyState.cs
+++ b/Assets/Source/Player/IUX/Activator/ActivatorReadyState.cs
@@ -2,38 +2,21 @@ namespace CreateAR.EnkluPlayer.IUX
 {
     /// <summary>
     /// State the button takes when it is ready for activation 
-    /// but not currently activating.
+    /// but not going to be interacted with.
     /// </summary>
     public class ActivatorReadyState : ActivatorState
     {
-        /// <summary>
-        /// Configuration for widgets.
-        /// </summary>
-        private readonly WidgetConfig _config;
-
         /// <summary>
         /// Activator.
         /// </summary>
         private readonly ActivatorPrimitive _activator;
 
         /// <summary>
-        /// Activation as the state is entered.
-        /// </summary>
-        private float _initialActivation;
-
-        /// <summary>
-        /// Elapsed time in the state.
-        /// </summary>
-        private float _elapsed;
-
-        /// <summary>
         /// Constructor.
         /// </summary>
-        /// <param name="config">Configuration for widgets.</param>
         /// <param name="activator">Activator.</param>
         /// <param name="schema">Schema to use.</param>
         public ActivatorReadyState(
-            WidgetConfig config,
             ActivatorPrimitive activator,
             ElementSchema schema)
             : base(
@@ -41,7 +24,6 @@ namespace CreateAR.EnkluPlayer.IUX
                 schema.Get<string>("ready.color"),
                 schema.Get<float>("ready.frameScale"))
         {
-            _config = config;
             _activator = activator;
         }
 
@@ -51,8 +33,7 @@ namespace CreateAR.EnkluPlayer.IUX
         /// <param name="context"></param>
         public override void Enter(object context)
         {
-            _elapsed = 0.0f;
-            _initialActivation = _activator.Activation;
+            _activator.Activation = 0;
         }
 
         /// <summary>
@@ -63,14 +44,7 @@ namespace CreateAR.EnkluPlayer.IUX
         {
             if (_activator.Focused)
             {
-                _activator.Activating();
-            }
-            else
-            {
-                _elapsed += deltaTime;
-
-                // recede the activation percentage over time
-                _activator.Activation = _initialActivation * _config.GetFillDelay(_elapsed);
+                _activator.Imminent();
             }
         }
     }

--- a/Assets/Source/Player/IUX/Activator/ActivatorRenderer.cs
+++ b/Assets/Source/Player/IUX/Activator/ActivatorRenderer.cs
@@ -12,8 +12,9 @@ namespace CreateAR.EnkluPlayer.IUX
     {
         /// <summary>
         /// Factor for buffer.
+        /// TODO: Make this variable / schema driven
         /// </summary>
-        private const float AUTO_GEN_BUFFER_FACTOR = 2.0f;
+        private const float COLLIDER_BUFFER_FACTOR = 2.0f;
 
         /// <summary>
         /// Dependencies.
@@ -22,11 +23,6 @@ namespace CreateAR.EnkluPlayer.IUX
         private TweenConfig _tweens;
         private ColorConfig _colors;
         private ActivatorPrimitive _activator;
-
-        /// <summary>
-        /// For losing focus.
-        /// </summary>
-        private BoxCollider _bufferCollider;
 
         /// <summary>
         /// True iff the renderer is initialized.
@@ -82,11 +78,16 @@ namespace CreateAR.EnkluPlayer.IUX
         private float _tweenDuration;
         private Col4 _frameColor;
         private float _alpha;
+        
+        /// <summary>
+        /// Bounding radius of the Activator with padding.
+        /// </summary>
+        public float FocusRadius { get; private set; }
 
         /// <summary>
-        /// Bounding radius of the activator.
+        /// Bounding radius of the Activator.
         /// </summary>
-        public float Radius { get; private set; }
+        public float ActivateRadius { get; private set; }
 
         /// <summary>
         /// Alpha!
@@ -127,7 +128,7 @@ namespace CreateAR.EnkluPlayer.IUX
             _activator.OnActivated += Activator_OnActivated;
 
             GenerateBufferCollider();
-            Radius = CalculateRadius();
+            CalculateRadius();
             Alpha = activator.Alpha;
 
             if (Aim != null)
@@ -182,7 +183,7 @@ namespace CreateAR.EnkluPlayer.IUX
         /// <summary>
         /// Returns the radius of the widget.
         /// </summary>
-        private float CalculateRadius()
+        private void CalculateRadius()
         {
             var radius = 1f;
             if (null != FocusCollider)
@@ -194,9 +195,13 @@ namespace CreateAR.EnkluPlayer.IUX
                     size.y * scale.y,
                     size.z * scale.z);
                 radius = 0.5f * (scaledSize.x + scaledSize.y + scaledSize.z) / 3f;
+
+                // Bump the collider size up to increase padding
+                FocusCollider.size = FocusCollider.size * COLLIDER_BUFFER_FACTOR;
             }
 
-            return radius;
+            ActivateRadius = radius;
+            FocusRadius = ActivateRadius * COLLIDER_BUFFER_FACTOR;
         }
 
         /// <summary>
@@ -209,13 +214,6 @@ namespace CreateAR.EnkluPlayer.IUX
                 Log.Error(this, "Missing FocusCollider for AutoGenerateBufferCollider!");
                 return;
             }
-
-            if (_bufferCollider == null)
-            {
-                _bufferCollider = gameObject.AddComponent<BoxCollider>();
-            }
-
-            _bufferCollider.size = FocusCollider.size * AUTO_GEN_BUFFER_FACTOR;
         }
 
         /// <summary>
@@ -223,9 +221,7 @@ namespace CreateAR.EnkluPlayer.IUX
         /// </summary>
         private void UpdateColliders()
         {
-            FocusCollider.enabled = _activator.Interactable;
-
-            _bufferCollider.enabled = _activator.Focused;
+            FocusCollider.enabled = true;
         }
 
         /// <summary>

--- a/Assets/Source/Player/IUX/Activator/ActivatorRenderer.cs
+++ b/Assets/Source/Player/IUX/Activator/ActivatorRenderer.cs
@@ -14,7 +14,7 @@ namespace CreateAR.EnkluPlayer.IUX
         /// Factor for buffer.
         /// TODO: Make this variable / schema driven
         /// </summary>
-        private const float COLLIDER_BUFFER_FACTOR = 2.0f;
+        private const float COLLIDER_BUFFER_FACTOR = 3.0f;
 
         /// <summary>
         /// Dependencies.

--- a/Assets/Source/Player/IUX/Activator/ActivatorRenderer.cs
+++ b/Assets/Source/Player/IUX/Activator/ActivatorRenderer.cs
@@ -11,12 +11,6 @@ namespace CreateAR.EnkluPlayer.IUX
     public class ActivatorRenderer : MonoBehaviour
     {
         /// <summary>
-        /// Factor for buffer.
-        /// TODO: Make this variable / schema driven
-        /// </summary>
-        private const float COLLIDER_BUFFER_FACTOR = 3.0f;
-
-        /// <summary>
         /// Dependencies.
         /// </summary>
         private WidgetConfig _config;
@@ -127,7 +121,6 @@ namespace CreateAR.EnkluPlayer.IUX
 
             _activator.OnActivated += Activator_OnActivated;
 
-            GenerateBufferCollider();
             CalculateRadius();
             Alpha = activator.Alpha;
 
@@ -197,23 +190,11 @@ namespace CreateAR.EnkluPlayer.IUX
                 radius = 0.5f * (scaledSize.x + scaledSize.y + scaledSize.z) / 3f;
 
                 // Bump the collider size up to increase padding
-                FocusCollider.size = FocusCollider.size * COLLIDER_BUFFER_FACTOR;
+                FocusCollider.size = FocusCollider.size * _config.AimBufferFactor;
             }
 
             ActivateRadius = radius;
-            FocusRadius = ActivateRadius * COLLIDER_BUFFER_FACTOR;
-        }
-
-        /// <summary>
-        /// Generate buffer collider
-        /// </summary>
-        private void GenerateBufferCollider()
-        {
-            if (FocusCollider == null)
-            {
-                Log.Error(this, "Missing FocusCollider for AutoGenerateBufferCollider!");
-                return;
-            }
+            FocusRadius = ActivateRadius * _config.AimBufferFactor;
         }
 
         /// <summary>

--- a/Assets/Source/Player/IUX/Activator/ActivatorRenderer.cs
+++ b/Assets/Source/Player/IUX/Activator/ActivatorRenderer.cs
@@ -189,7 +189,7 @@ namespace CreateAR.EnkluPlayer.IUX
                     size.z * scale.z);
                 radius = 0.5f * (scaledSize.x + scaledSize.y + scaledSize.z) / 3f;
 
-                // Bump the collider size up to increase padding
+                // Bump the collider size up to account for the buffer factor
                 FocusCollider.size = FocusCollider.size * _config.AimBufferFactor;
             }
 
@@ -202,7 +202,7 @@ namespace CreateAR.EnkluPlayer.IUX
         /// </summary>
         private void UpdateColliders()
         {
-            FocusCollider.enabled = true;
+            FocusCollider.enabled = _activator.Interactable;
         }
 
         /// <summary>

--- a/Assets/Source/Player/IUX/Activator/IRaycaster.cs
+++ b/Assets/Source/Player/IUX/Activator/IRaycaster.cs
@@ -12,5 +12,15 @@
         /// <param name="direction">Direction.</param>
         /// <returns></returns>
         bool Raycast(Vec3 origin, Vec3 direction);
+
+        /// <summary>
+        /// Raycast. Includes hit/collider positions.
+        /// </summary>
+        /// <param name="origin">Start position.</param>
+        /// <param name="direction">Direction.</param>
+        /// <param name="hitPosition">Hit position.</param>
+        /// <param name="colliderCenter">Collider position.</param>
+        /// <returns></returns>
+        bool Raycast(Vec3 origin, Vec3 direction, out Vec3 hitPosition, out Vec3 colliderCenter);
     }
 }

--- a/Assets/Source/Player/IUX/Interaction/Cursor.cs
+++ b/Assets/Source/Player/IUX/Interaction/Cursor.cs
@@ -31,7 +31,7 @@ namespace CreateAR.EnkluPlayer.IUX
         /// <summary>
         /// How well is the user aiming.
         /// </summary>
-        private float _aim = -1;
+        private float _aim = 0;
 
         /// <summary>
         /// Scale of the points.
@@ -131,8 +131,9 @@ namespace CreateAR.EnkluPlayer.IUX
 
                 // Only show the cursor when hovering over an Interactable on Hololens
                 // TODO: Should all apps ignore the cursor outside of edit mode?
-                if(DeviceHelper.IsHoloLens() && !_playConfig.Edit) {
-                    visible = visible && _aim >= 0;
+                if (DeviceHelper.IsHoloLens() && !_playConfig.Edit)
+                {
+                    visible = visible && _intention.Focus != null;
                 }
 
                 LocalVisible = visible;
@@ -245,7 +246,7 @@ namespace CreateAR.EnkluPlayer.IUX
         /// </summary>
         private void UpdateAim()
         {
-            _aim = -1.0f;
+            _aim = 0;
 
             var interactive = _intention.Focus;
             if (null != interactive)

--- a/Assets/Source/Player/IUX/Interaction/IInteractable.cs
+++ b/Assets/Source/Player/IUX/Interaction/IInteractable.cs
@@ -44,9 +44,10 @@ namespace CreateAR.EnkluPlayer.IUX
 
         /// <summary>
         /// (IUX PATENT)
-        /// A scalar percentage [0..1] representing targeting clarity.
-        /// 0 = low clarity - may be aiming at the edge of this.
-        /// 1 = high clarity - definitely targeting at center of this.
+        /// A scalar percentage [-1..1] representing targeting clarity.
+        /// -1 = no clarity - aim is in the buffer area.
+        ///  0 = low clarity - may be aiming at the edge of this.
+        ///  1 = high clarity - definitely targeting at center of this.
         /// </summary>
         float Aim { get; }
 

--- a/Assets/Source/Player/IUX/Interaction/IntentionManager.cs
+++ b/Assets/Source/Player/IUX/Interaction/IntentionManager.cs
@@ -34,7 +34,7 @@ namespace CreateAR.EnkluPlayer.IUX
         private Vec3 _lastMouseOrigin;
 
         /// <summary>
-        /// Last state of mouse do
+        /// Last state of mouse down.
         /// </summary>
         private Vec3 _lastMouseForward;
 
@@ -259,18 +259,36 @@ namespace CreateAR.EnkluPlayer.IUX
         /// </summary>
         private void UpdateFocus()
         {
+            IInteractable closestInteractable = null;
+            var closestAngle = Mathf.Infinity;
+
             var all = Interactables.All;
             for (int i = 0, len = all.Count; i < len; i++)
             {
                 var interactable = all[i];
-                if (interactable.Interactable && interactable.Raycast(Origin, Forward))
+                Vec3 hitPos;
+                Vec3 colliderPos;
+                if (interactable.Interactable && 
+                    interactable.Raycast(Origin, Forward, out hitPos, out colliderPos))
                 {
-                    Focus = interactable;
-                    return;
+                    var colliderDir = colliderPos - Origin;
+                    var angleToCollider = Vec3.Angle(Forward, colliderDir);
+
+                    if (angleToCollider < closestAngle)
+                    {
+                        closestInteractable = interactable;
+                        closestAngle = angleToCollider;
+                    }
                 }
             }
+
+            if (closestInteractable != null)
+            {
+                Focus = closestInteractable;
+                return;
+            }
             
-            // determine if the current interactable should lose focuse
+            // determine if the current interactable should lose focus.
             if (Focus != null)
             {
                 if (!Focus.Raycast(Origin, Forward))

--- a/Assets/Source/Player/IUX/Widget/Button/ButtonWidget.cs
+++ b/Assets/Source/Player/IUX/Widget/Button/ButtonWidget.cs
@@ -102,6 +102,12 @@ namespace CreateAR.EnkluPlayer.IUX
         }
 
         /// <inheritdoc />
+        public bool Raycast(Vec3 origin, Vec3 direction, out Vec3 hitPos, out Vec3 colliderPos)
+        {
+            return Activator.Raycast(origin, direction, out hitPos, out colliderPos);
+        }
+
+        /// <inheritdoc />
         public bool Focused
         {
             get { return Activator.Focused; }

--- a/Assets/Source/Player/IUX/Widget/InteractableWidget.cs
+++ b/Assets/Source/Player/IUX/Widget/InteractableWidget.cs
@@ -126,6 +126,9 @@ namespace CreateAR.EnkluPlayer.IUX
         public abstract bool Raycast(Vec3 origin, Vec3 direction);
 
         /// <inheritdoc />
+        public abstract bool Raycast(Vec3 origin, Vec3 direction, out Vec3 hitPos, out Vec3 colliderPos);
+
+        /// <inheritdoc />
         protected override void LoadInternalAfterChildren()
         {
             base.LoadInternalAfterChildren();

--- a/Assets/Source/Player/IUX/Widget/Slider/SliderWidget.cs
+++ b/Assets/Source/Player/IUX/Widget/Slider/SliderWidget.cs
@@ -231,6 +231,12 @@ namespace CreateAR.EnkluPlayer.IUX
         {
             return _handle.Raycast(origin, direction);
         }
+
+        /// <inheritdoc />
+        public bool Raycast(Vec3 origin, Vec3 direction, out Vec3 hitPos, out Vec3 colliderPos)
+        {
+            return _handle.Raycast(origin, direction, out hitPos, out colliderPos);
+        }
         
         /// <inheritdoc />
         protected override void LoadInternalBeforeChildren()

--- a/Assets/Source/Player/IUX/Widget/WidgetConfig.cs
+++ b/Assets/Source/Player/IUX/Widget/WidgetConfig.cs
@@ -13,9 +13,14 @@ namespace CreateAR.EnkluPlayer.IUX
         public IconConfig Icons;
 
         /// <summary>
-        /// Color of the aim widget as a function of aim percentage.
+        /// The scale factor a widget can use for a buffer.
         /// </summary>
         [Header("Aim")]
+        public float AimBufferFactor = 3.0f;
+
+        /// <summary>
+        /// Color of the aim widget as a function of aim percentage.
+        /// </summary>
         public Gradient AimFeedbackColor;
 
         /// <summary>


### PR DESCRIPTION
- Adds a new Activator state: `ActivatorImminentState`. Not all that in love with the naming.
This state essentially takes the responsibilities `ActivatorReadyState` had. it transitions to Activating when needed, and de-progresses a canceled "activating" as needed. The ready state now is just idle. In the future we can style ready & close differently if we'd like.

- Adds a new Raycast overload to `IRaycaster`.

- Changes Aim range from 0 -> 1 to -1 -> 1.
The new area in the range signifies how close the user is to the activator while in the buffer area.

- `IntentionManager` no longer early outs.
To handle large buffers & overlapping buttons, IntentionManager no longer early outs when it finds a valid raycast. Instead it continues raycasting, and then picks the Interactable with the closest angular offset.