### PR TITLE
Add Quat.FromToRotation, and with it, `transform.lookAt` in scripting

### DIFF
--- a/Assets/Editor/Test/Scripting/QuatJsApi_Tests.cs
+++ b/Assets/Editor/Test/Scripting/QuatJsApi_Tests.cs
@@ -76,17 +76,18 @@ namespace CreateAR.EnkluPlayer.Test.Scripting
                 var dir = TestData.DirectionArray[i];
 
                 var enkluRot = _engine.Run<Quat>(
-                    string.Format("q.lookAt(vec3({0}, {1}, {2}));", dir.x, dir.y, dir.z));
+                    string.Format("q.fromToRotation(vec3({0}, {1}, {2}));", dir.x, dir.y, dir.z));
                 var unityRot = Quaternion.FromToRotation(Vector3.forward, dir.ToVector());
 
                 var enkluEuler = enkluRot.ToQuaternion().eulerAngles;
                 var unityEuler = unityRot.eulerAngles;
 
                 var equal = Mathf.Approximately(enkluEuler.x, unityEuler.x)
-                            && Mathf.Approximately(enkluEuler.y, unityEuler.y)
-                            && Mathf.Approximately(enkluEuler.z, unityEuler.z);
+                         && Mathf.Approximately(enkluEuler.y, unityEuler.y)
+                         && Mathf.Approximately(enkluEuler.z, unityEuler.z);
 
-                if (!equal) {
+                if (!equal) 
+                {
                     Log.Error(this, enkluRot + " " + unityRot);
                     Log.Error(this, dir + " " + enkluEuler + " " + unityEuler);
                 }

--- a/Assets/Editor/Test/Scripting/QuatJsApi_Tests.cs
+++ b/Assets/Editor/Test/Scripting/QuatJsApi_Tests.cs
@@ -3,7 +3,6 @@ using CreateAR.Commons.Unity.Logging;
 using UnityEngine;
 using NUnit.Framework;
 using Jint;
-using Jint.Native;
 
 namespace CreateAR.EnkluPlayer.Test.Scripting
 {
@@ -21,6 +20,7 @@ namespace CreateAR.EnkluPlayer.Test.Scripting
             });
 
             _engine.SetValue("q", QuatMethods.Instance);
+            _engine.SetValue("vec3", new Func<float, float, float, Vec3>(Vec3Methods.create));
             _engine.SetValue("quat", new Func<float, float, float, float, Quat>(QuatMethods.create));
         }
 
@@ -65,6 +65,31 @@ namespace CreateAR.EnkluPlayer.Test.Scripting
                     Log.Error(this, euler + " " + quatStr + " " + result);
                 }
 
+                Assert.IsTrue(equal);
+            }
+        }
+
+        [Test]
+        public void FromToRotation()
+        {
+            for (var i = 0; i < TestData.DirectionArray.Length; i++) {
+                var dir = TestData.DirectionArray[i];
+
+                var enkluRot = _engine.Run<Quat>(
+                    string.Format("q.lookAt(vec3({0}, {1}, {2}));", dir.x, dir.y, dir.z));
+                var unityRot = Quaternion.FromToRotation(Vector3.forward, dir.ToVector());
+
+                var enkluEuler = enkluRot.ToQuaternion().eulerAngles;
+                var unityEuler = unityRot.eulerAngles;
+
+                var equal = Mathf.Approximately(enkluEuler.x, unityEuler.x)
+                            && Mathf.Approximately(enkluEuler.y, unityEuler.y)
+                            && Mathf.Approximately(enkluEuler.z, unityEuler.z);
+
+                if (!equal) {
+                    Log.Error(this, enkluRot + " " + unityRot);
+                    Log.Error(this, dir + " " + enkluEuler + " " + unityEuler);
+                }
                 Assert.IsTrue(equal);
             }
         }

--- a/Assets/Editor/Test/Scripting/TestData.cs
+++ b/Assets/Editor/Test/Scripting/TestData.cs
@@ -47,9 +47,9 @@
             Vec3.Forward,
             Vec3.Right,
             Vec3.Up,
-            new Vec3(  0,  0, -1),
-            new Vec3(  0, -1,  0),
-            new Vec3( -1,  0,  0),
+            new Vec3( 0,  0, -1),
+            new Vec3( 0, -1,  0),
+            new Vec3(-1,  0,  0),
 
             new Vec3( 1,  1,  1),
             new Vec3( 1,  1, -1),

--- a/Assets/Editor/Test/Scripting/TestData.cs
+++ b/Assets/Editor/Test/Scripting/TestData.cs
@@ -1,9 +1,14 @@
 ﻿namespace CreateAR.EnkluPlayer.Test.Scripting
 {
+    /// <summary>
+    /// A readonly set of data to be used across multiple tests.
+    /// </summary>
     public static class TestData
     {
-        // A handful of rotations from different axes/quadrants
-        public static Vec3[] EulerArray =
+        /// <summary>
+        /// A handful of rotations from different axes/quadrants.
+        /// </summary>
+        public static readonly Vec3[] EulerArray =
         {
             new Vec3( 0,     0,     0),
             new Vec3( 90,    0,    0),
@@ -32,6 +37,28 @@
             new Vec3(-120,  160, -140),
             new Vec3(-120, -160,  140),
             new Vec3(-120, -160, -140),
+        };
+
+        /// <summary>
+        /// A handful of direction vectors from different axes/quadrants.
+        /// </summary>
+        public static readonly Vec3[] DirectionArray =
+        {
+            Vec3.Forward,
+            Vec3.Right,
+            Vec3.Up,
+            new Vec3(  0,  0, -1),
+            new Vec3(  0, -1,  0),
+            new Vec3( -1,  0,  0),
+
+            new Vec3( 1,  1,  1),
+            new Vec3( 1,  1, -1),
+            new Vec3( 1, -1,  1),
+            new Vec3( 1, -1, -1),
+            new Vec3(-1,  1,  1),
+            new Vec3(-1,  1, -1),
+            new Vec3(-1, -1,  1),
+            new Vec3(-1, -1, -1)
         };
     }
 }

--- a/Assets/Editor/Test/Scripting/TransformJsApi_Tests.cs
+++ b/Assets/Editor/Test/Scripting/TransformJsApi_Tests.cs
@@ -19,6 +19,8 @@ namespace CreateAR.EnkluPlayer.Test.Scripting
             _engine = new Engine();
             _element = new ElementJs(null, null, _engine, new Element());
             _engine.SetValue("this", _element);
+            _engine.SetValue("v", Vec3Methods.Instance);
+            _engine.SetValue("q", QuatMethods.Instance);
 
             _gameObject = new GameObject("TransformJsApi Tests");
         }
@@ -27,7 +29,7 @@ namespace CreateAR.EnkluPlayer.Test.Scripting
         public void Forward()
         {
             // Test that our forward matches Unity's over a variety of euler rotations
-            for (int i = 0; i < TestData.EulerArray.Length; i++)
+            for (var i = 0; i < TestData.EulerArray.Length; i++)
             {
                 var euler = TestData.EulerArray[i];
                 _element.transform.rotation = Quat.Euler(euler);
@@ -38,6 +40,19 @@ namespace CreateAR.EnkluPlayer.Test.Scripting
                 var unityForward = _gameObject.transform.forward;
                 Assert.IsTrue(Vector3.Angle(enkluForward.ToVector(), unityForward) < Mathf.Epsilon);
             }
+        }
+
+        [Test]
+        public void LookAt()
+        {
+            var rotation = _engine.Run<Quat>(@"
+                this.this.transform.lookAt(v.normalize(v.create(1, 0, 0)));
+                this.this.transform.rotation;
+            ");
+
+            var euler = rotation.ToQuaternion().eulerAngles;
+            Debug.Log(euler);
+            Assert.IsTrue(euler.Approximately(new Vector3(0, 90, 0)));
         }
     }
 }

--- a/Assets/Editor/Test/Scripting/TransformJsApi_Tests.cs
+++ b/Assets/Editor/Test/Scripting/TransformJsApi_Tests.cs
@@ -51,7 +51,6 @@ namespace CreateAR.EnkluPlayer.Test.Scripting
             ");
 
             var euler = rotation.ToQuaternion().eulerAngles;
-            Debug.Log(euler);
             Assert.IsTrue(euler.Approximately(new Vector3(0, 90, 0)));
         }
     }

--- a/Assets/Source/Math/Quat.cs
+++ b/Assets/Source/Math/Quat.cs
@@ -158,6 +158,38 @@ namespace CreateAR.EnkluPlayer
         }
 
         /// <summary>
+        /// Returns the rotation from one Vec3 to another Vec3.
+        ///
+        /// References: https://stackoverflow.com/questions/1171849/finding-quaternion-representing-the-rotation-from-one-vector-to-another
+        /// </summary>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        /// <returns></returns>
+        public static Quat FromToRotation(Vec3 from, Vec3 to)
+        {
+            var dot = Vec3.Dot(from, to);
+            var cross = Vec3.Cross(from, to);
+
+            // Edge case 
+            if (dot == -1 && cross.MagnitudeSqr == 0)
+            {
+                return new Quat(1, 0, 0, 0);
+            }
+
+            var w = (float) Math.Sqrt(from.MagnitudeSqr * to.MagnitudeSqr) + dot;
+            var len = (float) Math.Sqrt(cross.x * cross.x + cross.y * cross.y + cross.z * cross.z + w * w);
+
+            // Normalize the Quat
+            Quat rot = new Quat(
+                cross.x / len,
+                cross.y / len,
+                cross.z / len,
+                w / len
+            );
+            return rot;
+        }
+
+        /// <summary>
         /// Identity.
         /// </summary>
         public static Quat Identity

--- a/Assets/Source/Math/Vec3.cs
+++ b/Assets/Source/Math/Vec3.cs
@@ -262,6 +262,32 @@ namespace CreateAR.EnkluPlayer
         }
 
         /// <summary>
+        /// Tests strict equality of Vector components.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        public static bool operator ==(Vec3 a, Vec3 b)
+        {
+            return a.x == b.x
+                && a.y == b.y
+                && a.z == b.z;
+        }
+
+        /// <summary>
+        /// Tests strict inequality of Vector components.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        public static bool operator !=(Vec3 a, Vec3 b)
+        {
+            return a.x != b.x
+                || a.y != b.y
+                || a.z != b.z;
+        }
+
+        /// <summary>
         /// Returns the squared distance between two Vec3's.
         /// </summary>
         /// <param name="from"></param>

--- a/Assets/Source/Player/Scripting/Interface/Elements/ElementJs.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/ElementJs.cs
@@ -267,7 +267,7 @@ namespace CreateAR.EnkluPlayer.Scripting
 
         /// <summary>
         /// Returns the position of this ElementJs relative to another ElementJs. This value should not
-        /// be cached as elements aren't guarenteed to sit under the same world anchor.
+        /// be cached as elements aren't guaranteed to sit under the same world anchor.
         ///
         /// TODO: Make this more friendly/understandable for people unfamiliar with anchoring woes.
         /// </summary>

--- a/Assets/Source/Player/Scripting/Interface/Elements/ElementTransformJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/ElementTransformJsApi.cs
@@ -1,4 +1,7 @@
-﻿using CreateAR.EnkluPlayer.IUX;
+﻿using CreateAR.Commons.Unity.Logging;
+using CreateAR.EnkluPlayer.IUX;
+using Jint.Native;
+using UnityEngine;
 
 namespace CreateAR.EnkluPlayer.Scripting
 {
@@ -27,36 +30,59 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// </summary>
         private readonly ElementSchemaProp<Vec3> _scaleProp;
 
-        /// <summary>
-        /// Position.
-        /// </summary>
+        /// <inheritdoc />
         public Vec3 position
         {
             get { return _positionProp.Value; }
             set { _positionProp.Value = value; }
         }
-        
-        /// <summary>
-        /// Rotation.
-        /// </summary>
+
+        /// <inheritdoc />
         public Quat rotation
         {
             get { return Quat.Euler(_rotationProp.Value); }
             set { _rotationProp.Value = value.ToQuaternion().eulerAngles.ToVec(); }
         }
-        
-        /// <summary>
-        /// Scale.
-        /// </summary>
+
+        /// <inheritdoc />
         public Vec3 scale
         {
             get { return _scaleProp.Value; }
             set { _scaleProp.Value = value; }
         }
 
+        /// <inheritdoc />
+        public Vec3 worldPosition
+        {
+            get
+            {
+                var widget = _element as Widget;
+                if (widget != null)
+                {
+                    return widget.GameObject.transform.position.ToVec();
+                }
+
+                // Eventually, work up our local transform tree until we hit a widget?
+                Log.Warning(this, "worldPosition not designed for non-widgets. Tell us your use case!");
+                return position;
+            }
+        }
+
+        /// <summary>
+        /// Forward.
+        /// </summary>
         public Vec3 forward
         {
             get { return Quat.Mult(rotation, Vec3.Forward); }
+        }
+
+        /// <summary>
+        /// Turns this transform to face a direction.
+        /// </summary>
+        /// <param name="direction"></param>
+        public void lookAt(Vec3 direction)
+        {
+            rotation = Quat.FromToRotation(Vec3.Forward, direction);
         }
 
         /// <summary>

--- a/Assets/Source/Player/Scripting/Interface/Elements/IElementTransformJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/IElementTransformJsApi.cs
@@ -19,5 +19,10 @@
         /// Scale.
         /// </summary>
         Vec3 scale { get; set; }
+
+        /// <summary>
+        /// World position. Do not cache this value as world anchors will shift.
+        /// </summary>
+        Vec3 worldPosition { get; }
     }
 }

--- a/Assets/Source/Player/Scripting/Interface/Math/QuatMethods.cs
+++ b/Assets/Source/Player/Scripting/Interface/Math/QuatMethods.cs
@@ -39,7 +39,12 @@
             return Quat.Euler(x, y, z);
         }
 
-        public Quat lookAt(Vec3 direction)
+        /// <summary>
+        /// Creates a Quat that looks at the target Vec3 direction.
+        /// </summary>
+        /// <param name="direction"></param>
+        /// <returns></returns>
+        public Quat fromToRotation(Vec3 direction)
         {
             return Quat.FromToRotation(Vec3.Forward, direction);
         }

--- a/Assets/Source/Player/Scripting/Interface/Math/QuatMethods.cs
+++ b/Assets/Source/Player/Scripting/Interface/Math/QuatMethods.cs
@@ -38,5 +38,10 @@
         {
             return Quat.Euler(x, y, z);
         }
+
+        public Quat lookAt(Vec3 direction)
+        {
+            return Quat.FromToRotation(Vec3.Forward, direction);
+        }
     }
 }

--- a/Assets/Source/Player/Scripting/Interface/UnityTransformJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/UnityTransformJsApi.cs
@@ -37,9 +37,7 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// </summary>
         private Vec3 _scale;
 
-        /// <summary>
-        /// Position.
-        /// </summary>
+        /// <inheritdoc />
         public Vec3 position
         {
             get
@@ -53,9 +51,7 @@ namespace CreateAR.EnkluPlayer.Scripting
             }
         }
 
-        /// <summary>
-        /// Rotation.
-        /// </summary>
+        /// <inheritdoc />
         public Quat rotation
         {
             get
@@ -69,9 +65,7 @@ namespace CreateAR.EnkluPlayer.Scripting
             }
         }
 
-        /// <summary>
-        /// Scale.
-        /// </summary>
+        /// <inheritdoc />
         public Vec3 scale
         {
             get
@@ -83,6 +77,12 @@ namespace CreateAR.EnkluPlayer.Scripting
                 Log.Warning(this, "Attempting to set UnityTransform value");
                 //UnityTransform.localScale = new Vector3(_scale.x, _scale.y, _scale.z);
             }
+        }
+
+        /// <inheritdoc />
+        public Vec3 worldPosition
+        {
+            get { return UnityTransform.position.ToVec(); }
         }
 
         /// <summary>


### PR DESCRIPTION
Title says most of it. Added another rotation/transform method to be used in scripting. I thought about overloading lookAt to support both a Vec3 and an ElementJs instance, but for now it's just directions.

I also exposed a `worldPosition` on transforms. `positionRelativeTo` works but feels weird/cumbersome to use. Maybe this is fine, as long as the docs have a lot of "do not cache" warnings/notes surrounding world based transform data?