### PR TITLE
Defer script refreshing until after the content assembler has finished

### DIFF
--- a/Assets/Source/Player/IUX/Content/ContentWidget.cs
+++ b/Assets/Source/Player/IUX/Content/ContentWidget.cs
@@ -227,7 +227,6 @@ namespace CreateAR.EnkluPlayer
             _scriptsProp.OnChanged += Scripts_OnChanged;
             
             UpdateAsset();
-            RefreshScripts();
         }
 
         /// <inheritdoc />
@@ -494,6 +493,8 @@ namespace CreateAR.EnkluPlayer
             }
 
             _onAssetLoaded.Succeed(this);
+
+            RefreshScripts();
         }
 
         /// <summary>

--- a/Assets/Source/Player/IUX/Content/ContentWidget.cs
+++ b/Assets/Source/Player/IUX/Content/ContentWidget.cs
@@ -494,6 +494,7 @@ namespace CreateAR.EnkluPlayer
 
             _onAssetLoaded.Succeed(this);
 
+            // trigger refresh, so component specific references are new
             RefreshScripts();
         }
 


### PR DESCRIPTION
Title says it all. Realized there was a race condition where scripts could load before assets, meaning references to an animator could be invalid when a script first runs.

To fix this, and for EK-290, `ContentWidget` now refreshes scripts after the `ContentAssembler` has finished constructing an asset. Scripts still refresh on their own changes as well.