### PR TITLE
transform.positionRelativeTo

### DIFF
--- a/Assets/Source/Player/Scripting/Interface/Elements/ElementJs.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/ElementJs.cs
@@ -273,8 +273,11 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// </summary>
         /// <param name="element"></param>
         /// <returns></returns>
+        [Obsolete]
         public Vec3 positionRelativeTo(ElementJs other)
         {
+            Log.Warning(this, "Element.positionRelativeTo is obsolete. Please use Element.transform.positionRelativeTo instead.");
+
             var thisAsWidget = _element as Widget;
             var otherAsWidget = other._element as Widget;
 

--- a/Assets/Source/Player/Scripting/Interface/Elements/ElementTransformJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/ElementTransformJsApi.cs
@@ -14,6 +14,12 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// Element that we're wrapping.
         /// </summary>
         private readonly Element _element;
+
+        /// <summary>
+        /// Element as a ContentWidget.
+        /// TODO: Remove this when world positioning better handled.
+        /// </summary>
+        private readonly Widget _widget;
         
         /// <summary>
         /// Backing position prop.
@@ -59,15 +65,27 @@ namespace CreateAR.EnkluPlayer.Scripting
             get { return Quat.Mult(rotation, Vec3.Forward); }
         }
 
-        /// <summary>
-        /// Turns this transform to face a direction.
-        /// </summary>
-        /// <param name="direction"></param>
-        public void lookAt(Vec3 direction)
+        /// <inheritdoc />
+        [DenyJsAccess]
+        public Vec3 worldPosition
         {
-            rotation = Quat.FromToRotation(Vec3.Forward, direction);
+            get
+            {
+                if (_widget != null)
+                {
+                    return _widget.GameObject.transform.position.ToVec();
+                }
+                Log.Warning(this, "Trying to get worldPosition for non-widget. Tell us your use-case!");
+                return position;
+            }
         }
 
+        /// <inheritdoc />
+        public Vec3 positionRelativeTo(IEntityJs entity)
+        {
+            return worldPosition - entity.transform.worldPosition;
+        }
+        
         /// <summary>
         /// Constructor.
         /// </summary>
@@ -75,10 +93,20 @@ namespace CreateAR.EnkluPlayer.Scripting
         public ElementTransformJsApi(Element element)
         {
             _element = element;
+            _widget = element as Widget;
 
             _positionProp = _element.Schema.Get<Vec3>("position");
             _rotationProp = _element.Schema.Get<Vec3>("rotation");
             _scaleProp = _element.Schema.Get<Vec3>("scale");
+        }
+
+        /// <summary>
+        /// Turns this transform to face a direction.
+        /// </summary>
+        /// <param name="direction"></param>
+        public void lookAt(Vec3 direction)
+        {
+            rotation = Quat.FromToRotation(Vec3.Forward, direction);
         }
     }
 }

--- a/Assets/Source/Player/Scripting/Interface/Elements/IElementTransformJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/IElementTransformJsApi.cs
@@ -19,5 +19,19 @@
         /// Scale.
         /// </summary>
         Vec3 scale { get; set; }
+
+        /// <summary>
+        /// Returns the position of this transform relative to another entity. This value should not
+        /// be cached as elements aren't guaranteed to sit under the same world anchor.
+        ///
+        /// TODO: Make this more friendly/understandable for people unfamiliar with anchoring woes.
+        /// </summary>
+        /// <param name="entity"></param>
+        /// <returns></returns>
+        Vec3 positionRelativeTo(IEntityJs entity);
+
+
+        [DenyJsAccess]
+        Vec3 worldPosition { get; }
     }
 }

--- a/Assets/Source/Player/Scripting/Interface/Elements/IElementTransformJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/IElementTransformJsApi.cs
@@ -30,7 +30,9 @@
         /// <returns></returns>
         Vec3 positionRelativeTo(IEntityJs entity);
 
-
+        /// <summary>
+        /// World position. DO NOT cache this value, as it shifts with world anchor readjustment.
+        /// </summary>
         [DenyJsAccess]
         Vec3 worldPosition { get; }
     }

--- a/Assets/Source/Player/Scripting/Interface/Math/Vec3Methods.cs
+++ b/Assets/Source/Player/Scripting/Interface/Math/Vec3Methods.cs
@@ -14,7 +14,7 @@
         /// Constants.
         /// </summary>
         public readonly Vec3 one = new Vec3(1, 1, 1);
-        public readonly Vec3 zero = new Vec3(1, 1, 1);
+        public readonly Vec3 zero = new Vec3(0, 0, 0);
         public readonly Vec3 up = new Vec3(0, 1, 0);
         public readonly Vec3 forward = new Vec3(0, 0, 1);
         public readonly Vec3 right = new Vec3(1, 0, 0);

--- a/Assets/Source/Player/Scripting/Interface/UnityTransformJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/UnityTransformJsApi.cs
@@ -79,6 +79,12 @@ namespace CreateAR.EnkluPlayer.Scripting
             }
         }
 
+        /// <inheritdoc />
+        public Vec3 worldPosition
+        {
+            get { return UnityTransform.position.ToVec(); }
+        }
+
         /// <summary>
         /// Updates <see cref="position"/>, <see cref="rotation"/>, and <see cref="scale"/> to match the underlying Unity Transform's values.
         /// </summary>
@@ -98,6 +104,12 @@ namespace CreateAR.EnkluPlayer.Scripting
                 UnityTransform.localScale.x,
                 UnityTransform.localScale.y,
                 UnityTransform.localScale.z);
+        }
+
+        /// <inheritdoc />
+        public Vec3 positionRelativeTo(IEntityJs entity)
+        {
+            return worldPosition - entity.transform.worldPosition;
         }
     }
 }


### PR DESCRIPTION
New scripting use case requires an Element to move to the player's position. Before, usage of this was always in moving an Element to another Element close to the player. So with that, `positionRelativeTo` is moved from `ElementJs` to `ElementTransformJs` so that `PlayerJs` can use it as well.

I'd bet I'm the only one who uses this method, but still since it's in the current docs, I made the existing ElementJs based usage throw a deprecation warning instead of just removing it.