### PR TITLE
Bugfix: Scripts on assetless elements load again

### DIFF
--- a/Assets/Source/Player/IUX/Content/AssetAssembler.cs
+++ b/Assets/Source/Player/IUX/Content/AssetAssembler.cs
@@ -91,6 +91,11 @@ namespace CreateAR.EnkluPlayer
 
             if (string.IsNullOrEmpty(assetId))
             {
+                // empty assets are valid
+                if (OnAssemblyUpdated != null)
+                {
+                    OnAssemblyUpdated();
+                }
                 return;
             }
 

--- a/Assets/Source/Player/IUX/Content/ContentWidget.cs
+++ b/Assets/Source/Player/IUX/Content/ContentWidget.cs
@@ -479,23 +479,26 @@ namespace CreateAR.EnkluPlayer
         {
             LogVerbose("Assembly complete.");
 
-            // parent + orient
             _assetGameObject = _assembler.Assembly;
-            _assetGameObject.name = _srcAssetProp.Value;
-            _assetGameObject.transform.SetParent(GameObject.transform, false);
-            _assetGameObject.SetActive(true);
 
-            // setup collider
-            var bounds = _assembler.Bounds;
-            var collider = EditCollider;
-            if (null != collider)
+            if (_assetGameObject != null)
             {
-                collider.center = bounds.center;
-                collider.size = bounds.size;
+                // parent + orient
+                _assetGameObject.name = _srcAssetProp.Value;
+                _assetGameObject.transform.SetParent(GameObject.transform, false);
+                _assetGameObject.SetActive(true);
+
+                // setup collider
+                var bounds = _assembler.Bounds;
+                var collider = EditCollider;
+                if (null != collider) {
+                    collider.center = bounds.center;
+                    collider.size = bounds.size;
+                }
+
+                _onAssetLoaded.Succeed(this);
             }
-
-            _onAssetLoaded.Succeed(this);
-
+            
             // trigger refresh, so component specific references are new
             RefreshScripts();
         }


### PR DESCRIPTION
Fix a bug I introduced today. When script refreshing was deferred until after assets finished loading, it failed to handle the case where scripts can be attached to Elements without assets.

Now, the AssetAssembler invokes its callback if it early-outs with no URL (errors still act the same). 