### PR TITLE
ScreenWidget actually appears to be screen based again

### DIFF
--- a/Assets/Source/Player/IUX/Widget/ScreenWidget.cs
+++ b/Assets/Source/Player/IUX/Widget/ScreenWidget.cs
@@ -18,41 +18,6 @@ namespace CreateAR.EnkluPlayer.IUX
         private ElementSchemaProp<float> _distanceProp;
 
         /// <summary>
-        /// How much directional drift to ignore
-        /// </summary>
-        private ElementSchemaProp<float> _stabilizationProp;
-
-        /// <summary>
-        /// How fast (deg/sec) to update the position
-        /// </summary>
-        private ElementSchemaProp<float> _smoothingProp;
-
-        /// <summary>
-        /// A stable position near the intent's direction.
-        /// </summary>
-        private Vec3 _stabilizedForward;
-
-        /// <summary>
-        /// The previous stable position.
-        /// </summary>
-        private Vec3 _lastStableForward;
-
-        /// <summary>
-        /// The current forward, a value between stable & last stable.
-        /// </summary>
-        private Vec3 _interpolatedForward;
-
-        /// <summary>
-        /// The angular distance between stable/last.
-        /// </summary>
-        private float _lerpDist = 0;
-
-        /// <summary>
-        /// The current transition progress between stable/last.
-        /// </summary>
-        private float _lerpAcc = 0;
-
-        /// <summary>
         /// Constructor.
         /// </summary>
         public ScreenWidget(
@@ -64,8 +29,6 @@ namespace CreateAR.EnkluPlayer.IUX
             : base(gameObject, layers, tweens, colors)
         {
             _intention = intention;
-
-            _interpolatedForward = _stabilizedForward = _intention.Forward;
         }
 
         /// <inheritdoc />
@@ -73,9 +36,7 @@ namespace CreateAR.EnkluPlayer.IUX
         {
             base.LoadInternalAfterChildren();
 
-            _distanceProp = Schema.Get<float>("distance");
-            _stabilizationProp = Schema.Get<float>("stabilization");
-            _smoothingProp = Schema.Get<float>("smoothing");
+            _distanceProp = Schema.GetOwn("distance", 1f);
         }
 
         /// <inheritdoc />
@@ -83,27 +44,9 @@ namespace CreateAR.EnkluPlayer.IUX
         {
             base.UpdateInternal();
 
-            // Update stabilized forward as needed
-            if (Vec3.Angle(_stabilizedForward, _intention.Forward) > _stabilizationProp.Value)
-            {
-                _lastStableForward = _interpolatedForward;
-                _stabilizedForward = _intention.Forward;
-
-                _lerpDist = Vec3.Angle(_stabilizedForward, _interpolatedForward);
-                _lerpAcc = 0;
-            }
-            
-            // Update the interpolated forward as needed
-            if (_lerpAcc < 1)
-            {
-                var step = (_smoothingProp.Value * Time.deltaTime) / _lerpDist;
-                _lerpAcc = Mathf.Min(1, _lerpAcc + step);
-                _interpolatedForward = Vec3.Lerp(_lastStableForward, _stabilizedForward, _lerpAcc).Normalized;
-            }
-
-            var pos = _intention.Origin + _distanceProp.Value * _interpolatedForward;
+            var pos = _intention.Origin + _distanceProp.Value * _intention.Forward;
             GameObject.transform.position = pos.ToVector();
-            GameObject.transform.forward = _interpolatedForward.ToVector();
+            GameObject.transform.forward = _intention.Forward.ToVector();
         }
     }
 }

--- a/Assets/Source/Player/IUX/Widget/ScreenWidget.cs
+++ b/Assets/Source/Player/IUX/Widget/ScreenWidget.cs
@@ -40,7 +40,7 @@ namespace CreateAR.EnkluPlayer.IUX
         }
 
         /// <inheritdoc />
-        protected override void UpdateInternal()
+        protected override void LateUpdateInternal()
         {
             base.UpdateInternal();
 


### PR DESCRIPTION
Reverted the smoothing that I added, and swapped the positioning to work on `LateUpdateInternal` now.

Switching to late does help tracking as you're moving your head, which is expected. When holding your head "still" you can still see some wobble from slight movements. But, maybe a better fix for that can come down the road!