### PR TITLE
MaterialJsApi & AudioJsApi

### DIFF
--- a/Assets/Source/Player/Scripting/Interface/Elements/AudioJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/AudioJsApi.cs
@@ -145,5 +145,23 @@ namespace CreateAR.EnkluPlayer
         {
             _audio.maxDistance = distance;
         }
+
+        /// <summary>
+        /// Gets the doppler level.
+        /// </summary>
+        /// <returns></returns>
+        public float getDoplerLevel()
+        {
+            return _audio.dopplerLevel;
+        }
+
+        /// <summary>
+        /// Sets the doppler level.
+        /// </summary>
+        /// <param name="doppler"></param>
+        public void setDoplerLevel(float doppler)
+        {
+            _audio.dopplerLevel = doppler;
+        }
     }
 }

--- a/Assets/Source/Player/Scripting/Interface/Elements/AudioJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/AudioJsApi.cs
@@ -1,0 +1,149 @@
+﻿using UnityEngine;
+
+namespace CreateAR.EnkluPlayer
+{
+    /// <summary>
+    /// An interface to Unity's AudioSource.
+    /// </summary>
+    public class AudioJsApi
+    {
+        /// <summary>
+        /// Underlying AudioSource to wrap.
+        /// </summary>
+        private readonly AudioSource _audio;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="audio"></param>
+        public AudioJsApi(AudioSource audio)
+        {
+            _audio = audio;
+        }
+
+        /// <summary>
+        /// Gets the volume.
+        /// </summary>
+        /// <returns></returns>
+        public float getVolume()
+        {
+            return _audio.volume;
+        }
+
+        /// <summary>
+        /// Sets the volume.
+        /// </summary>
+        /// <param name="volume"></param>
+        public void setVolume(float volume)
+        {
+            _audio.volume = volume;
+        }
+
+        /// <summary>
+        /// Gets looping.
+        /// </summary>
+        /// <returns></returns>
+        public bool getLoop()
+        {
+            return _audio.loop;
+        }
+
+        /// <summary>
+        /// Sets looping.
+        /// </summary>
+        /// <param name="loop"></param>
+        public void setLoop(bool loop)
+        {
+            _audio.loop = loop;
+        }
+
+        /// <summary>
+        /// Gets mute.
+        /// </summary>
+        /// <returns></returns>
+        public bool getMute()
+        {
+            return _audio.mute;
+        }
+
+        /// <summary>
+        /// Sets mute.
+        /// </summary>
+        public void setMute(bool mute)
+        {
+            _audio.mute = mute;
+        }
+
+        /// <summary>
+        /// Gets playOnAwake.
+        /// </summary>
+        /// <returns></returns>
+        public bool getPlayOnAwake()
+        {
+            return _audio.playOnAwake;
+        }
+
+        /// <summary>
+        /// Sets playOnAwake.
+        /// </summary>
+        /// <param name="playOnAwake"></param>
+        public void setPlayOnAwake(bool playOnAwake)
+        {
+            _audio.playOnAwake = playOnAwake;
+        }
+
+        /// <summary>
+        /// Gets spatial blend.
+        /// </summary>
+        /// <returns></returns>
+        public float getSpatialBlend()
+        {
+            return _audio.spatialBlend;
+        }
+
+        /// <summary>
+        /// Sets spatial blend.
+        /// </summary>
+        /// <param name="blend"></param>
+        public void setSpatialBlend(float blend)
+        {
+            _audio.spatialBlend = blend;
+        }
+
+        /// <summary>
+        /// Gets min distance.
+        /// </summary>
+        /// <returns></returns>
+        public float getMinDistance()
+        {
+            return _audio.minDistance;
+        }
+
+        /// <summary>
+        /// Sets min distance.
+        /// </summary>
+        /// <param name="distance"></param>
+        public void setMinDistance(float distance)
+        {
+            _audio.minDistance = distance;
+        }
+
+        /// <summary>
+        /// Gets max distance.
+        /// </summary>
+        /// <returns></returns>
+        public float getMaxDistance()
+        {
+            return _audio.maxDistance;
+        }
+
+        /// <summary>
+        /// Sets max distance.
+        /// </summary>
+        /// <param name="distance"></param>
+        public void setMaxDistance(float distance)
+        {
+            _audio.maxDistance = distance;
+        }
+    }
+}

--- a/Assets/Source/Player/Scripting/Interface/Elements/AudioJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/AudioJsApi.cs
@@ -22,146 +22,75 @@ namespace CreateAR.EnkluPlayer
         }
 
         /// <summary>
-        /// Gets the volume.
+        /// Volume.
         /// </summary>
-        /// <returns></returns>
-        public float getVolume()
+        public float volume
         {
-            return _audio.volume;
+            get { return _audio.volume; }
+            set { _audio.volume = value; }
         }
 
         /// <summary>
-        /// Sets the volume.
+        /// Loop.
         /// </summary>
-        /// <param name="volume"></param>
-        public void setVolume(float volume)
+        public bool loop
         {
-            _audio.volume = volume;
+            get { return _audio.loop; }
+            set { _audio.loop = value; }
         }
 
         /// <summary>
-        /// Gets looping.
+        /// Mute.
         /// </summary>
-        /// <returns></returns>
-        public bool getLoop()
+        public bool mute
         {
-            return _audio.loop;
+            get { return _audio.mute; }
+            set { _audio.mute = value; }
         }
 
         /// <summary>
-        /// Sets looping.
+        /// Whether the audio plays on awake or not.
         /// </summary>
-        /// <param name="loop"></param>
-        public void setLoop(bool loop)
+        public bool playOnAwake
         {
-            _audio.loop = loop;
+            get { return _audio.playOnAwake; }
+            set { _audio.playOnAwake = value; }
         }
 
         /// <summary>
-        /// Gets mute.
+        /// Spatial Blend. 0: 2D, 1:3D
         /// </summary>
-        /// <returns></returns>
-        public bool getMute()
+        public float spatialBlend
         {
-            return _audio.mute;
+            get { return _audio.spatialBlend; }
+            set { _audio.spatialBlend = value; }
         }
 
         /// <summary>
-        /// Sets mute.
+        /// Minimum distance.
         /// </summary>
-        public void setMute(bool mute)
+        public float minDistance
         {
-            _audio.mute = mute;
+            get { return _audio.minDistance; }
+            set { _audio.minDistance = value; }
         }
 
         /// <summary>
-        /// Gets playOnAwake.
+        /// Maximum distance.
         /// </summary>
-        /// <returns></returns>
-        public bool getPlayOnAwake()
+        public float maxDistance
         {
-            return _audio.playOnAwake;
+            get { return _audio.maxDistance; }
+            set { _audio.maxDistance = value; }
         }
 
         /// <summary>
-        /// Sets playOnAwake.
+        /// Doppler level.
         /// </summary>
-        /// <param name="playOnAwake"></param>
-        public void setPlayOnAwake(bool playOnAwake)
+        public float dopplerLevel
         {
-            _audio.playOnAwake = playOnAwake;
-        }
-
-        /// <summary>
-        /// Gets spatial blend.
-        /// </summary>
-        /// <returns></returns>
-        public float getSpatialBlend()
-        {
-            return _audio.spatialBlend;
-        }
-
-        /// <summary>
-        /// Sets spatial blend.
-        /// </summary>
-        /// <param name="blend"></param>
-        public void setSpatialBlend(float blend)
-        {
-            _audio.spatialBlend = blend;
-        }
-
-        /// <summary>
-        /// Gets min distance.
-        /// </summary>
-        /// <returns></returns>
-        public float getMinDistance()
-        {
-            return _audio.minDistance;
-        }
-
-        /// <summary>
-        /// Sets min distance.
-        /// </summary>
-        /// <param name="distance"></param>
-        public void setMinDistance(float distance)
-        {
-            _audio.minDistance = distance;
-        }
-
-        /// <summary>
-        /// Gets max distance.
-        /// </summary>
-        /// <returns></returns>
-        public float getMaxDistance()
-        {
-            return _audio.maxDistance;
-        }
-
-        /// <summary>
-        /// Sets max distance.
-        /// </summary>
-        /// <param name="distance"></param>
-        public void setMaxDistance(float distance)
-        {
-            _audio.maxDistance = distance;
-        }
-
-        /// <summary>
-        /// Gets the doppler level.
-        /// </summary>
-        /// <returns></returns>
-        public float getDoplerLevel()
-        {
-            return _audio.dopplerLevel;
-        }
-
-        /// <summary>
-        /// Sets the doppler level.
-        /// </summary>
-        /// <param name="doppler"></param>
-        public void setDoplerLevel(float doppler)
-        {
-            _audio.dopplerLevel = doppler;
+            get { return _audio.dopplerLevel; }
+            set { _audio.dopplerLevel = value; }
         }
     }
 }

--- a/Assets/Source/Player/Scripting/Interface/Elements/AudioJsApi.cs.meta
+++ b/Assets/Source/Player/Scripting/Interface/Elements/AudioJsApi.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1b88bc75d12b694b8fba05ee312d313
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Source/Player/Scripting/Interface/Elements/ContentElementJs.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/ContentElementJs.cs
@@ -66,7 +66,7 @@ namespace CreateAR.EnkluPlayer.Scripting
             }
 
             var unityRenderer = contentWidget.GetComponent<Renderer>();
-            if (unityRenderer != null)
+            if (unityRenderer != null && unityRenderer.sharedMaterial != null)
             {
                 material = new MaterialJsApi(unityRenderer);
             }

--- a/Assets/Source/Player/Scripting/Interface/Elements/ContentElementJs.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/ContentElementJs.cs
@@ -20,6 +20,8 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// </summary>
         public MaterialJsApi material { get; private set; }
 
+        public AudioJsApi audio { get; private set; }
+
         /// <summary>
         /// Constructor.
         /// </summary>
@@ -68,6 +70,16 @@ namespace CreateAR.EnkluPlayer.Scripting
             else
             {
                 material = null;
+            }
+
+            var unityAudioSource = contentWidget.GetComponent<AudioSource>();
+            if (unityAudioSource != null)
+            {
+                audio = new AudioJsApi(unityAudioSource);
+            }
+            else
+            {
+                audio = null;
             }
         }
     }

--- a/Assets/Source/Player/Scripting/Interface/Elements/ContentElementJs.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/ContentElementJs.cs
@@ -16,6 +16,11 @@ namespace CreateAR.EnkluPlayer.Scripting
         public AnimatorJsApi animator { get; private set; }
 
         /// <summary>
+        /// The material interface.
+        /// </summary>
+        public MaterialJsApi material { get; private set; }
+
+        /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="scripts"></param>
@@ -46,8 +51,15 @@ namespace CreateAR.EnkluPlayer.Scripting
         private void CacheAnimator(ContentWidget contentWidget)
         {
             var unityAnimator = contentWidget.GetComponent<Animator>();
-            if(unityAnimator != null) {
+            if (unityAnimator != null) 
+            {
                 animator = new AnimatorJsApi(unityAnimator);
+            }
+
+            var unityRenderer = contentWidget.GetComponent<Renderer>();
+            if (unityRenderer != null)
+            {
+                material = new MaterialJsApi(unityRenderer);
             }
         }
     }

--- a/Assets/Source/Player/Scripting/Interface/Elements/ContentElementJs.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/ContentElementJs.cs
@@ -20,6 +20,9 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// </summary>
         public MaterialJsApi material { get; private set; }
 
+        /// <summary>
+        /// The audio interface.
+        /// </summary>
         public AudioJsApi audio { get; private set; }
 
         /// <summary>

--- a/Assets/Source/Player/Scripting/Interface/Elements/ContentElementJs.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/ContentElementJs.cs
@@ -55,11 +55,19 @@ namespace CreateAR.EnkluPlayer.Scripting
             {
                 animator = new AnimatorJsApi(unityAnimator);
             }
+            else
+            {
+                animator = null;
+            }
 
             var unityRenderer = contentWidget.GetComponent<Renderer>();
             if (unityRenderer != null)
             {
                 material = new MaterialJsApi(unityRenderer);
+            }
+            else
+            {
+                material = null;
             }
         }
     }

--- a/Assets/Source/Player/Scripting/Interface/Elements/MaterialJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/MaterialJsApi.cs
@@ -1,0 +1,34 @@
+﻿using UnityEngine;
+
+namespace CreateAR.EnkluPlayer.Scripting
+{
+    public class MaterialJsApi
+    {
+        private readonly Renderer _renderer;
+
+        public MaterialJsApi(Renderer renderer)
+        {
+            _renderer = renderer;
+        }
+
+        public void setFloat(string param, float value)
+        {
+            _renderer.sharedMaterial.SetFloat(param, value);
+        }
+
+        public void setInt(string param, int value)
+        {
+            _renderer.sharedMaterial.SetInt(param, value);
+        }
+
+        public void setVector(string param, Vec3 value)
+        {
+            _renderer.sharedMaterial.SetVector(param, value.ToVector());
+        }
+
+        public void setShaderPass(string pass, bool enabled)
+        {
+            _renderer.sharedMaterial.SetShaderPassEnabled(pass, enabled);
+        }
+    }
+}

--- a/Assets/Source/Player/Scripting/Interface/Elements/MaterialJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/MaterialJsApi.cs
@@ -2,30 +2,75 @@
 
 namespace CreateAR.EnkluPlayer.Scripting
 {
+    /// <summary>
+    /// An interface to Unity's Material system.
+    /// Properties of an Element's shared material can be modified.
+    /// </summary>
     public class MaterialJsApi
     {
+        /// <summary>
+        /// Underlying Unity Renderer to modify.
+        /// </summary>
         private readonly Renderer _renderer;
 
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="renderer"></param>
         public MaterialJsApi(Renderer renderer)
         {
             _renderer = renderer;
         }
 
+        /// <summary>
+        /// Sets a float material property.
+        /// </summary>
+        /// <param name="param"></param>
+        /// <param name="value"></param>
         public void setFloat(string param, float value)
         {
             _renderer.sharedMaterial.SetFloat(param, value);
         }
 
+        /// <summary>
+        /// Sets an integer material property.
+        /// </summary>
+        /// <param name="param"></param>
+        /// <param name="value"></param>
         public void setInt(string param, int value)
         {
             _renderer.sharedMaterial.SetInt(param, value);
         }
 
+        /// <summary>
+        /// Sets a Vector material property with a Vec3.
+        /// </summary>
+        /// <param name="param"></param>
+        /// <param name="value"></param>
         public void setVector(string param, Vec3 value)
         {
             _renderer.sharedMaterial.SetVector(param, value.ToVector());
         }
 
+        /// <summary>
+        /// Sets a Vector material property with a Vec3 & alpha.
+        /// TODO: Add in a Vec4 and use that instead.
+        /// </summary>
+        /// <param name="param"></param>
+        /// <param name="value"></param>
+        /// <param name="alpha"></param>
+        public void setVector(string param, Vec3 value, float alpha)
+        {
+            _renderer.sharedMaterial.SetVector(
+                param, 
+                new Vector4(value.x, value.y, value.z, alpha));
+        }
+
+        /// <summary>
+        /// Sets a named shader pass enabled/disabled.
+        /// </summary>
+        /// <param name="pass"></param>
+        /// <param name="enabled"></param>
         public void setShaderPass(string pass, bool enabled)
         {
             _renderer.sharedMaterial.SetShaderPassEnabled(pass, enabled);

--- a/Assets/Source/Player/Scripting/Interface/Elements/MaterialJsApi.cs.meta
+++ b/Assets/Source/Player/Scripting/Interface/Elements/MaterialJsApi.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e6c7d2bdba8314d4ba092daf9aaabaf8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Finally got around to testing this- new MaterialJsApi lets scripts change shader parameters on the fly.

For now, everything uses the renderer's shared material. Eventually we can add support for optionally splitting into unique instances, etc. Also, I didn't want to rush and make a `Vec4` class and/or expose `Col4` to scripting yet, so I added a quick overload to allow changing a color + alpha if needed.

Also, added an AudioJsApi for modifying an AudioSource attached to an uploaded asset.