### PR TITLE
Add extra, optional, "admin" guarding around specific voice commands.

### DIFF
--- a/Assets/Source/Application/ApplicationConfig.cs
+++ b/Assets/Source/Application/ApplicationConfig.cs
@@ -659,6 +659,11 @@ namespace CreateAR.EnkluPlayer
         public bool DisableVoiceLock = false;
 
         /// <summary>
+        /// If true, requires saying "admin" before admin voice commands.
+        /// </summary>
+        public bool DisableAdminLock = false;
+
+        /// <summary>
         /// Overrides settings.
         /// </summary>
         /// <param name="config">Other config.</param>
@@ -667,6 +672,11 @@ namespace CreateAR.EnkluPlayer
             if (config.DisableVoiceLock)
             {
                 DisableVoiceLock = true;
+            }
+
+            if (config.DisableAdminLock)
+            {
+                DisableAdminLock = true;
             }
         }
     }

--- a/Assets/Source/Application/States/Play/Hmd/Controllers/HmdDesignController.cs
+++ b/Assets/Source/Application/States/Play/Hmd/Controllers/HmdDesignController.cs
@@ -393,8 +393,8 @@ namespace CreateAR.EnkluPlayer
 
             _primaryAnchor.Setup();
 
-            _voice.Register("menu", Voice_OnPlayMenu);
-            _voice.Register("edit", Voice_OnEdit);
+            _voice.Register("menu", Voice_OnPlayMenu, true);
+            _voice.Register("edit", Voice_OnEdit, true);
 
             // for editor only
             if (UnityEngine.Application.isEditor)

--- a/Assets/Source/Application/States/Play/Hmd/Controllers/HmdDesignController.cs
+++ b/Assets/Source/Application/States/Play/Hmd/Controllers/HmdDesignController.cs
@@ -393,8 +393,8 @@ namespace CreateAR.EnkluPlayer
 
             _primaryAnchor.Setup();
 
-            _voice.Register("menu", Voice_OnPlayMenu, true);
-            _voice.Register("edit", Voice_OnEdit, true);
+            _voice.RegisterAdmin("menu", Voice_OnPlayMenu);
+            _voice.RegisterAdmin("edit", Voice_OnEdit);
 
             // for editor only
             if (UnityEngine.Application.isEditor)

--- a/Assets/Source/Input/Voice/IVoiceCommandManager.cs
+++ b/Assets/Source/Input/Voice/IVoiceCommandManager.cs
@@ -13,7 +13,16 @@ namespace CreateAR.EnkluPlayer
         /// <param name="keyword">The keyword to look for.</param>
         /// <param name="delegate">The delegate that will be called.</param>
         /// <returns></returns>
-        bool Register(string keyword, Action<string> @delegate, bool adminCommand = false);
+        bool Register(string keyword, Action<string> @delegate);
+
+        /// <summary>
+        /// Registers a keyword for detection.
+        /// Admin keywords are guarded by the "admin" phrase.
+        /// </summary>
+        /// <param name="keyword">The keyword to look for.</param>
+        /// <param name="delegate">The delegate that will be called.</param>
+        /// <returns></returns>
+        bool RegisterAdmin(string keyword, Action<string> @delegate);
 
         /// <summary>
         /// Unregisters a keyword.

--- a/Assets/Source/Input/Voice/IVoiceCommandManager.cs
+++ b/Assets/Source/Input/Voice/IVoiceCommandManager.cs
@@ -13,7 +13,7 @@ namespace CreateAR.EnkluPlayer
         /// <param name="keyword">The keyword to look for.</param>
         /// <param name="delegate">The delegate that will be called.</param>
         /// <returns></returns>
-        bool Register(string keyword, Action<string> @delegate);
+        bool Register(string keyword, Action<string> @delegate, bool adminCommand = false);
 
         /// <summary>
         /// Unregisters a keyword.

--- a/Assets/Source/Input/Voice/PassthroughVoiceCommandManager.cs
+++ b/Assets/Source/Input/Voice/PassthroughVoiceCommandManager.cs
@@ -8,7 +8,7 @@ namespace CreateAR.EnkluPlayer
     public class PassthroughVoiceCommandManager : IVoiceCommandManager
     {
         /// <inheritdoc cref="IVoiceCommandManager"/>
-        public bool Register(string keyword, Action<string> @delegate)
+        public bool Register(string keyword, Action<string> @delegate, bool adminCommand = false)
         {
             return true;
         }

--- a/Assets/Source/Input/Voice/PassthroughVoiceCommandManager.cs
+++ b/Assets/Source/Input/Voice/PassthroughVoiceCommandManager.cs
@@ -8,7 +8,13 @@ namespace CreateAR.EnkluPlayer
     public class PassthroughVoiceCommandManager : IVoiceCommandManager
     {
         /// <inheritdoc cref="IVoiceCommandManager"/>
-        public bool Register(string keyword, Action<string> @delegate, bool adminCommand = false)
+        public bool Register(string keyword, Action<string> @delegate)
+        {
+            return true;
+        }
+
+        /// <inheritdoc cref="IVoiceCommandManager"/>
+        public bool RegisterAdmin(string keyword, Action<string> @delegate)
         {
             return true;
         }

--- a/Assets/Source/Input/Voice/VoiceCommandManager.cs
+++ b/Assets/Source/Input/Voice/VoiceCommandManager.cs
@@ -129,6 +129,9 @@ namespace CreateAR.EnkluPlayer
             _debugGuard.Start();
         }
 
+        /// <summary>
+        /// Rebuilds the admin guard.
+        /// </summary>
         private void RebuildAdminGuard()
         {
             if (null != _adminGuard)


### PR DESCRIPTION
Similar to the debug voice guard, there's a global config option to disable it. For individual voice registrations, an optional bool can be passed to make a command hide behind the admin guard.