### PR TITLE
Anchoring Bugs

### DIFF
--- a/Assets/Source/Application/States/Play/Hmd/IPrimaryAnchorManager.cs
+++ b/Assets/Source/Application/States/Play/Hmd/IPrimaryAnchorManager.cs
@@ -33,5 +33,11 @@ namespace CreateAR.EnkluPlayer
         /// Called to get reference to primary anchor
         /// </summary>
         WorldAnchorWidget Anchor { get; }
+
+        /// <summary>
+        /// Repositions an anchor's underlying GameObject relative to the primary anchor.
+        /// </summary>
+        /// <param name="anchor"></param>
+        void PositionRelatively(WorldAnchorWidget anchor);
     }
 }

--- a/Assets/Source/Application/States/Play/Hmd/PrimaryAnchorManager.cs
+++ b/Assets/Source/Application/States/Play/Hmd/PrimaryAnchorManager.cs
@@ -342,6 +342,7 @@ namespace CreateAR.EnkluPlayer
             }
         }
 
+        /// <inheritdoc />
         public void PositionRelatively(WorldAnchorWidget anchor)
         {
             PositionAnchorRelative(anchor, _lastTransformMatrix);

--- a/Assets/Source/Main.cs
+++ b/Assets/Source/Main.cs
@@ -65,6 +65,15 @@ namespace CreateAR.EnkluPlayer
                 _binder.GetInstance<PlayerJs>());
 	    }
 
+		/// <summary>
+		/// TODO: REMOVE THIS UNHOLY ABOMINATION. This is here because of a circular dependency between IElementFactory < == > IPrimaryAnchorManager
+		/// </summary>
+		/// <returns></returns>
+		public static IPrimaryAnchorManager PrimaryAnchorManager()
+		{
+			return _binder.GetInstance<IPrimaryAnchorManager>();
+		}
+
         /// <summary>
         /// Analogous to the main() function.
         /// </summary>

--- a/Assets/Source/Player/IUX/Element/ElementFactory.cs
+++ b/Assets/Source/Player/IUX/Element/ElementFactory.cs
@@ -40,7 +40,6 @@ namespace CreateAR.EnkluPlayer.IUX
         private readonly IMessageRouter _messages;
         private readonly IElementJsCache _jsCache;
         private readonly IElementJsFactory _elementJsFactory;
-        private readonly IPrimaryAnchorManager _anchorManager;
         private readonly ColorConfig _colors;
         private readonly TweenConfig _tweens;
         private readonly WidgetConfig _config;
@@ -83,7 +82,6 @@ namespace CreateAR.EnkluPlayer.IUX
             IMessageRouter messages,
             IElementJsCache jsCache,
             IElementJsFactory elementJsFactory,
-            IPrimaryAnchorManager anchorManager,
             ColorConfig colors,
             TweenConfig tweens,
             WidgetConfig config,
@@ -114,7 +112,6 @@ namespace CreateAR.EnkluPlayer.IUX
             _messages = messages;
             _jsCache = jsCache;
             _elementJsFactory = elementJsFactory;
-            _anchorManager = anchorManager;
             _appConfig = appConfig;
             
             // TODO: Load this all from data
@@ -438,7 +435,6 @@ namespace CreateAR.EnkluPlayer.IUX
                         _provider, 
                         _metrics, 
                         _messages, 
-                        _anchorManager, 
                         _appConfig);
                 }
                 case ElementTypes.QR_ANCHOR:

--- a/Assets/Source/Player/IUX/Element/ElementFactory.cs
+++ b/Assets/Source/Player/IUX/Element/ElementFactory.cs
@@ -40,7 +40,7 @@ namespace CreateAR.EnkluPlayer.IUX
         private readonly IMessageRouter _messages;
         private readonly IElementJsCache _jsCache;
         private readonly IElementJsFactory _elementJsFactory;
-        private readonly IDeviceMetaProvider _deviceMetaProvider;
+        private readonly IPrimaryAnchorManager _anchorManager;
         private readonly ColorConfig _colors;
         private readonly TweenConfig _tweens;
         private readonly WidgetConfig _config;
@@ -83,7 +83,7 @@ namespace CreateAR.EnkluPlayer.IUX
             IMessageRouter messages,
             IElementJsCache jsCache,
             IElementJsFactory elementJsFactory,
-            IDeviceMetaProvider deviceMetaProvider,
+            IPrimaryAnchorManager anchorManager,
             ColorConfig colors,
             TweenConfig tweens,
             WidgetConfig config,
@@ -114,7 +114,7 @@ namespace CreateAR.EnkluPlayer.IUX
             _messages = messages;
             _jsCache = jsCache;
             _elementJsFactory = elementJsFactory;
-            _deviceMetaProvider = deviceMetaProvider;
+            _anchorManager = anchorManager;
             _appConfig = appConfig;
             
             // TODO: Load this all from data
@@ -429,7 +429,17 @@ namespace CreateAR.EnkluPlayer.IUX
                 }
                 case ElementTypes.WORLD_ANCHOR:
                 {
-                    return new WorldAnchorWidget(new GameObject("WorldAnchor"), _layers, _tweens, _colors, _http, _provider, _metrics, _messages, _appConfig);
+                    return new WorldAnchorWidget(
+                        new GameObject("WorldAnchor"), 
+                        _layers, 
+                        _tweens, 
+                        _colors, 
+                        _http, 
+                        _provider, 
+                        _metrics, 
+                        _messages, 
+                        _anchorManager, 
+                        _appConfig);
                 }
                 case ElementTypes.QR_ANCHOR:
                 {

--- a/Assets/Source/Player/IUX/Widget/WorldAnchor/WorldAnchorWidget.cs
+++ b/Assets/Source/Player/IUX/Widget/WorldAnchor/WorldAnchorWidget.cs
@@ -58,6 +58,11 @@ namespace CreateAR.EnkluPlayer.IUX
         private readonly IMessageRouter _messages;
 
         /// <summary>
+        /// Allows for Anchor repositioning.
+        /// </summary>
+        private readonly IPrimaryAnchorManager _anchorManager;
+
+        /// <summary>
         /// Application config.
         /// </summary>
         private readonly ApplicationConfig _config;
@@ -152,6 +157,7 @@ namespace CreateAR.EnkluPlayer.IUX
             IWorldAnchorProvider provider,
             IMetricsService metrics,
             IMessageRouter messages,
+            IPrimaryAnchorManager anchorManager,
             ApplicationConfig config)
             : base(gameObject, layers, tweens, colors)
         {
@@ -178,6 +184,10 @@ namespace CreateAR.EnkluPlayer.IUX
         /// <param name="txns">Object to make txns with.</param>
         public void Export(string appId, string sceneId, IElementTxnManager txns)
         {
+            // Update this Anchor's position relative to a located Anchor
+            Log.Warning(this, "Export {0}", Status);
+            _anchorManager.PositionRelatively(this);
+            
             _pollStatus = false;
             Status = WorldAnchorStatus.IsExporting;
 

--- a/Assets/Source/Player/IUX/Widget/WorldAnchor/WorldAnchorWidget.cs
+++ b/Assets/Source/Player/IUX/Widget/WorldAnchor/WorldAnchorWidget.cs
@@ -186,7 +186,6 @@ namespace CreateAR.EnkluPlayer.IUX
         public void Export(string appId, string sceneId, IElementTxnManager txns)
         {
             // Update this Anchor's position relative to a located Anchor
-            Log.Warning(this, "Export {0}", Status);
             _anchorManager.PositionRelatively(this);
             
             _pollStatus = false;

--- a/Assets/Source/Player/IUX/Widget/WorldAnchor/WorldAnchorWidget.cs
+++ b/Assets/Source/Player/IUX/Widget/WorldAnchor/WorldAnchorWidget.cs
@@ -253,7 +253,7 @@ namespace CreateAR.EnkluPlayer.IUX
             _lockedProp = Schema.GetOwn("locked", false);
             _lockedProp.OnChanged += Locked_OnChanged;
             
-            var autoexport = Schema.GetOwn("autoexport", false).Value;
+            var autoexport = Schema.GetOwn("autoexport", true).Value;
             if (autoexport)
             {
                 _messages.Publish(MessageTypes.ANCHOR_AUTOEXPORT, this);

--- a/Assets/Source/Player/IUX/Widget/WorldAnchor/WorldAnchorWidget.cs
+++ b/Assets/Source/Player/IUX/Widget/WorldAnchor/WorldAnchorWidget.cs
@@ -157,7 +157,6 @@ namespace CreateAR.EnkluPlayer.IUX
             IWorldAnchorProvider provider,
             IMetricsService metrics,
             IMessageRouter messages,
-            IPrimaryAnchorManager anchorManager,
             ApplicationConfig config)
             : base(gameObject, layers, tweens, colors)
         {
@@ -166,6 +165,8 @@ namespace CreateAR.EnkluPlayer.IUX
             _metrics = metrics;
             _messages = messages;
             _config = config;
+
+            _anchorManager = Main.PrimaryAnchorManager();
         }
 
         /// <summary>

--- a/Assets/Source/Player/IUX/Widget/WorldAnchor/WorldAnchorWidget.cs
+++ b/Assets/Source/Player/IUX/Widget/WorldAnchor/WorldAnchorWidget.cs
@@ -240,7 +240,7 @@ namespace CreateAR.EnkluPlayer.IUX
             _versionProp = Schema.GetOwn("version", -1);
             _versionProp.OnChanged += Version_OnChanged;
 
-            _lockedProp = Schema.GetOwn("locked", true);
+            _lockedProp = Schema.GetOwn("locked", false);
             _lockedProp.OnChanged += Locked_OnChanged;
             
             var autoexport = Schema.GetOwn("autoexport", false).Value;


### PR DESCRIPTION
Fixes a few bugs with anchoring:

- Anchors are unable to be selected in the web editor.
`WorldAnchorWIdget` was being created with its `locked` schema set to true by default.

- Anchors made in the web editor wouldn't anchor in the correct position
New anchors were being placed immediately based on their schema & exported without first being repositioned. Adding the `none` anchor state to the relative positioning check fixed this.

- Anchors made in Hololens aren't creating properly
Similar to the web editor issue, Anchors weren't exporting with the correct transform data. Anchors now always re-position relatively before exporting.

- Multiple anchors from the web editor couldn't export
This one seemed to come for free. Tried it out a few times and multiple anchors all always exported.. Some anchoring code did change since we ran into that last, or maybe there is an issue where if one fails to save (poor wifi) the rest would fail.

To allow anchors to re-position themselves relatively, I added some support to the `IPrimaryAnchorManager`. It isn't perfect, and when more anchoring changes come in the next few weeks I want to revisit it. Right now anchors can be triggered for exporting or have their schema updated from a variety of different sources, it'd be nice to centralize that a bit more. I had to add an ugly hack to get around a circular dependency I created. I thought about adding `IElementFactory` to `VineImporter` and having that be responsible for creating Elements directly and not just their Descriptions, but that would have been a change that touched a lot of files and not something I wanted to do for a quick fix or without more thought.