### PR TITLE
Add press/release to IGestureManager

### DIFF
--- a/Assets/Editor/Test/Scripting/GestureJsApi_Tests.cs
+++ b/Assets/Editor/Test/Scripting/GestureJsApi_Tests.cs
@@ -50,6 +50,8 @@ namespace CreateAR.EnkluPlayer.Test.Scripting
         {
             public event Action<uint> OnPointerStarted;
             public event Action<uint> OnPointerEnded;
+            public event Action<uint> OnPointerPressed;
+            public event Action<uint> OnPointerReleased;
             public uint[] Pointers { get; private set; }
 
             public void SetPointers(uint[] ids)

--- a/Assets/Source/Input/Gesture/HoloLensGestureManager.cs
+++ b/Assets/Source/Input/Gesture/HoloLensGestureManager.cs
@@ -1,4 +1,4 @@
-﻿#if NETFX_CORE
+﻿#if UNITY_WSA
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -92,6 +92,12 @@ namespace CreateAR.EnkluPlayer
         public event Action<uint> OnPointerEnded;
 
         /// <inheritdoc />
+        public event Action<uint> OnPointerPressed;
+
+        /// <inheritdoc />
+        public event Action<uint> OnPointerReleased;
+
+        /// <inheritdoc />
         public uint[] Pointers
         {
             get
@@ -117,6 +123,8 @@ namespace CreateAR.EnkluPlayer
             InteractionManager.InteractionSourceDetected += Interactions_OnSourceDetected;
             InteractionManager.InteractionSourceLost += Interactions_OnSourceLost;
             InteractionManager.InteractionSourceUpdated += Interactions_OnSourceUpdated;
+            InteractionManager.InteractionSourcePressed += Interactions_OnSourcePressed;
+            InteractionManager.InteractionSourceReleased += Interactions_OnSourceReleased;
             
             _bootstrapper.BootstrapCoroutine(Update());
         }
@@ -129,6 +137,8 @@ namespace CreateAR.EnkluPlayer
             InteractionManager.InteractionSourceDetected -= Interactions_OnSourceDetected;
             InteractionManager.InteractionSourceLost -= Interactions_OnSourceLost;
             InteractionManager.InteractionSourceUpdated -= Interactions_OnSourceUpdated;
+            InteractionManager.InteractionSourcePressed -= Interactions_OnSourcePressed;
+            InteractionManager.InteractionSourceReleased -= Interactions_OnSourceReleased;
 
             _updateId = 0;
         }
@@ -309,6 +319,46 @@ namespace CreateAR.EnkluPlayer
             }
 
             data.Update(@event.state.sourcePose);
+        }
+
+        /// <summary>
+        /// Called when a source has been pressed.
+        /// </summary>
+        /// <param name="event">The event.</param>
+        private void Interactions_OnSourcePressed(InteractionSourcePressedEventArgs @event)
+        {
+            var id = @event.state.source.id;
+            var data = Data(id);
+            if (null == data)
+            {
+                Log.Warning(this, "Recieved a gesture pressed event for an untracked source.");
+                return;
+            }
+
+            if (null != OnPointerPressed)
+            {
+                OnPointerPressed(id);
+            }
+        }
+        
+        /// <summary>
+        /// Called when a source has been released.
+        /// </summary>
+        /// <param name="event">The event.</param>
+        private void Interactions_OnSourceReleased(InteractionSourceReleasedEventArgs @event)
+        {
+            var id = @event.state.source.id;
+            var data = Data(id);
+            if (null == data)
+            {
+                Log.Warning(this, "Recieved a gesture released event for an untracked source.");
+                return;
+            }
+
+            if (null != OnPointerReleased)
+            {
+                OnPointerReleased(id);
+            }
         }
     }
 }

--- a/Assets/Source/Input/Gesture/IGestureManager.cs
+++ b/Assets/Source/Input/Gesture/IGestureManager.cs
@@ -19,6 +19,16 @@ namespace CreateAR.EnkluPlayer
         event Action<uint> OnPointerEnded;
 
         /// <summary>
+        /// Dispatched when an existing gesture is pressed.
+        /// </summary>
+        event Action<uint> OnPointerPressed;
+
+        /// <summary>
+        /// Dispatched when an existing gesture is released. 
+        /// </summary>
+        event Action<uint> OnPointerReleased;
+
+        /// <summary>
         /// Array of active gesture IDs.
         /// </summary>
         uint[] Pointers { get; }

--- a/Assets/Source/Input/Gesture/PassthroughGestureManager.cs
+++ b/Assets/Source/Input/Gesture/PassthroughGestureManager.cs
@@ -15,6 +15,12 @@ namespace CreateAR.EnkluPlayer
         public event Action<uint> OnPointerEnded;
 
         /// <inheritdoc />
+        public event Action<uint> OnPointerPressed;
+
+        /// <inheritdoc />
+        public event Action<uint> OnPointerReleased;
+
+        /// <inheritdoc />
         public uint[] Pointers
         {
             get

--- a/Assets/Source/Player/Scripting/Interop/GestureJsInterface.cs
+++ b/Assets/Source/Player/Scripting/Interop/GestureJsInterface.cs
@@ -147,6 +147,8 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// </summary>
         private const string EVENT_POINTER_STARTED = "pointerstarted";
         private const string EVENT_POINTER_ENDED = "pointerended";
+        private const string EVENT_POINTER_PRESSED = "pointerpressed";
+        private const string EVENT_POINTER_RELEASED = "pointerreleased";
 
         /// <summary>
         /// Gesture interface.
@@ -159,7 +161,9 @@ namespace CreateAR.EnkluPlayer.Scripting
         private readonly Dictionary<string, List<JsFunc>> _listeners = new Dictionary<string, List<JsFunc>>
         {
             { EVENT_POINTER_STARTED, new List<JsFunc>() },
-            { EVENT_POINTER_ENDED, new List<JsFunc>() }
+            { EVENT_POINTER_ENDED, new List<JsFunc>() },
+            { EVENT_POINTER_PRESSED, new List<JsFunc>() },
+            { EVENT_POINTER_RELEASED, new List<JsFunc>() }
         };
 
         /// <summary>
@@ -170,6 +174,8 @@ namespace CreateAR.EnkluPlayer.Scripting
             _gestures = gestures;
             _gestures.OnPointerStarted += Gestures_OnPointerStarted;
             _gestures.OnPointerEnded += Gestures_OnPointerEnded;
+            _gestures.OnPointerPressed += Gestures_OnPointerPressed;
+            _gestures.OnPointerReleased += Gestures_OnPointerReleased;
         }
 
         /// <summary>
@@ -257,6 +263,36 @@ namespace CreateAR.EnkluPlayer.Scripting
             var parameters = new[] { new JsValue(id.ToString()) };
 
             var list = _listeners[EVENT_POINTER_ENDED].ToArray();
+            for (int i = 0, len = list.Length; i < len; i++)
+            {
+                list[i](null, parameters);
+            }
+        }
+
+        /// <summary>
+        /// Called when the gestures interface fires a pointer is pressed.
+        /// </summary>
+        /// <param name="id">Unique id of the pose.</param>
+        private void Gestures_OnPointerPressed(uint id)
+        {
+            var parameters = new[] { new JsValue(id.ToString()) };
+
+            var list = _listeners[EVENT_POINTER_PRESSED].ToArray();
+            for (int i = 0, len = list.Length; i < len; i++)
+            {
+                list[i](null, parameters);
+            }
+        }
+
+        /// <summary>
+        /// Called when the gestures interface fires a pointer is released.
+        /// </summary>
+        /// <param name="id">Unique id of the pose.</param>
+        private void Gestures_OnPointerReleased(uint id)
+        {
+            var parameters = new[] { new JsValue(id.ToString()) };
+            
+            var list = _listeners[EVENT_POINTER_RELEASED].ToArray();
             for (int i = 0, len = list.Length; i < len; i++)
             {
                 list[i](null, parameters);


### PR DESCRIPTION
Follows the patterns of the existing gesture handling, hooks onto InteractionManager's press/release so scripting can use taps if/when we want them.