### PR TITLE
Feature/schema jsapis

### DIFF
--- a/Assets/Editor/Test/Content/TestAnimator.cs
+++ b/Assets/Editor/Test/Content/TestAnimator.cs
@@ -1,9 +1,64 @@
-﻿using UnityEngine;
+﻿using System.Collections.Generic;
+using CreateAR.EnkluPlayer.Scripting;
+using UnityEngine;
 
 namespace CreateAR.EnkluPlayer.Test.Scripting
 {
-    public class TestAnimator : Animator
+    public class TestAnimator : IAnimator
     {
+        private Dictionary<string, bool> _bools = new Dictionary<string, bool>();
+        private Dictionary<string, float> _floats = new Dictionary<string, float>();
+        private Dictionary<string, int> _ints = new Dictionary<string, int>();
+        private AnimatorControllerParameter[] _parameters;
+
+        public TestAnimator(AnimatorControllerParameter[] parameters)
+        {
+            _parameters = parameters;
+        }
         
+        public AnimatorControllerParameter[] Parameters
+        {
+            get { return _parameters; }
+        }
+        
+        public bool GetBool(string name)
+        {
+            return _bools[name];
+        }
+
+        public void SetBool(string name, bool value)
+        {
+            _bools[name] = value;
+        }
+
+        public int GetInt(string name)
+        {
+            return _ints[name];
+        }
+
+        public void SetInt(string name, int value)
+        {
+            _ints[name] = value;
+        }
+
+        public float GetFloat(string name)
+        {
+            return _floats[name];
+        }
+
+        public void SetFloat(string name, float value)
+        {
+            _floats[name] = value;
+        }
+
+        public string CurrentClipName(int layer = 0)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool IsClipPlaying(string name, int layer = 0)
+        {
+            throw new System.NotImplementedException();
+        }
     }
 }

--- a/Assets/Editor/Test/Content/TestAnimator.cs
+++ b/Assets/Editor/Test/Content/TestAnimator.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+
+namespace CreateAR.EnkluPlayer.Test.Scripting
+{
+    public class TestAnimator : Animator
+    {
+        
+    }
+}

--- a/Assets/Editor/Test/Content/TestAnimator.cs.meta
+++ b/Assets/Editor/Test/Content/TestAnimator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 697a1596b3c0d3e49be02eb3c08cac23
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/Test/Content/TestAudioSource.cs
+++ b/Assets/Editor/Test/Content/TestAudioSource.cs
@@ -1,0 +1,16 @@
+using CreateAR.EnkluPlayer.Scripting;
+
+namespace CreateAR.EnkluPlayer.Test.Scripting
+{
+    public class TestAudioSource : IAudioSource
+    {
+        public float Volume { get; set; }
+        public bool Loop { get; set; }
+        public bool Mute { get; set; }
+        public bool PlayOnAwake { get; set; }
+        public float SpatialBlend { get; set; }
+        public float MinDistance { get; set; }
+        public float MaxDistance { get; set; }
+        public float DopplerLevel { get; set; }
+    }
+}

--- a/Assets/Editor/Test/Content/TestAudioSource.cs.meta
+++ b/Assets/Editor/Test/Content/TestAudioSource.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4c59638f89c547e988179f8d6ca23831
+timeCreated: 1543870388

--- a/Assets/Editor/Test/Content/TestMaterial.cs
+++ b/Assets/Editor/Test/Content/TestMaterial.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using CreateAR.EnkluPlayer.Scripting;
+using UnityEngine;
+
+namespace CreateAR.EnkluPlayer.Test.Scripting
+{
+    public class TestMaterial : IMaterial
+    {
+        private Dictionary<string, float> _floats = new Dictionary<string, float>();
+        private Dictionary<string, int> _ints = new Dictionary<string, int>();
+        private Dictionary<string, Vec3> _v3s = new Dictionary<string, Vec3>();
+        private Dictionary<string, Col4> _c4s = new Dictionary<string, Col4>();
+        
+        public float GetFloat(string param)
+        {
+            return _floats[param];
+        }
+        
+        public void SetFloat(string param, float value)
+        {
+            _floats[param] = value;
+        }
+
+        public int GetInt(string param)
+        {
+            return _ints[param];
+        }
+        
+        public void SetInt(string param, int value)
+        {
+            _ints[param] = value;
+        }
+
+        public Vec3 GetVec3(string param)
+        {
+            return _v3s[param];
+        }
+
+        public void SetVec3(string param, Vec3 value)
+        {
+            _v3s[param] = value;
+        }
+        
+        public Col4 GetCol4(string param)
+        {
+            return _c4s[param];
+        }
+
+        public void SetCol4(string param, Col4 value)
+        {
+            _c4s[param] = value;
+        }
+    }
+}

--- a/Assets/Editor/Test/Content/TestMaterial.cs.meta
+++ b/Assets/Editor/Test/Content/TestMaterial.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5da84d0c32885834795cb1917a1bc9bd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/Test/Content/TestRenderer.cs
+++ b/Assets/Editor/Test/Content/TestRenderer.cs
@@ -1,0 +1,14 @@
+using CreateAR.EnkluPlayer.Scripting;
+
+namespace CreateAR.EnkluPlayer.Test.Scripting
+{
+    public class TestRenderer : IRenderer
+    {
+        public IMaterial SharedMaterial { get; set; }
+
+        public TestRenderer(TestMaterial material)
+        {
+            SharedMaterial = material;
+        }
+    }
+}

--- a/Assets/Editor/Test/Content/TestRenderer.cs.meta
+++ b/Assets/Editor/Test/Content/TestRenderer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fea9adf4b9ff462d9063275833b63a93
+timeCreated: 1543792564

--- a/Assets/Editor/Test/Scripting/AnimatorJsApi_Tests.cs
+++ b/Assets/Editor/Test/Scripting/AnimatorJsApi_Tests.cs
@@ -45,6 +45,7 @@ namespace CreateAR.EnkluPlayer.Test.Scripting
 			_schema.Set("animator.Attack", 2);
 			
 			_animatorJsApi = new AnimatorJsApi(_schema, _animator);
+			_animatorJsApi.Setup();
 			
 			// Check values from schema were set
 			Assert.AreEqual(true, _animatorJsApi.getBool("Open"));
@@ -56,6 +57,7 @@ namespace CreateAR.EnkluPlayer.Test.Scripting
 		public void NoSchema()
 		{
 			_animatorJsApi = new AnimatorJsApi(_schema, _animator);
+			_animatorJsApi.Setup();
 			
 			// Set via API
 			_animatorJsApi.setBool("Open", true);

--- a/Assets/Editor/Test/Scripting/AnimatorJsApi_Tests.cs
+++ b/Assets/Editor/Test/Scripting/AnimatorJsApi_Tests.cs
@@ -1,0 +1,43 @@
+﻿using CreateAR.EnkluPlayer.IUX;
+using CreateAR.EnkluPlayer.Scripting;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace CreateAR.EnkluPlayer.Test.Scripting
+{
+	[TestFixture]
+	public class AnimatorJsApi_Tests
+	{
+		private ElementSchema _schema;
+		private Animator _animator;
+
+		private AnimatorJsApi _animatorJsApi;
+		
+		[SetUp]
+		public void Setup()
+		{
+			_schema = new ElementSchema();
+			_animator = new Animator();
+		}
+
+		[Test]
+		public void HasSchema()
+		{
+			_schema.Set("animator.Open", true);
+			_schema.Set("animator.Speed", 2.26f);
+			_schema.Set("animator.Attack", 2);
+			
+			_animatorJsApi = new AnimatorJsApi(_schema, _animator);
+			
+			Assert.AreEqual(true, _animatorJsApi.getBool("Open"));
+			Assert.AreEqual(2.26f, _animatorJsApi.getFloat("Speed"));
+			Assert.AreEqual(2, _animatorJsApi.getInteger("Attack"));
+		}
+
+		[Test]
+		public void NoSchema()
+		{
+			
+		}
+	}
+}

--- a/Assets/Editor/Test/Scripting/AnimatorJsApi_Tests.cs
+++ b/Assets/Editor/Test/Scripting/AnimatorJsApi_Tests.cs
@@ -9,15 +9,32 @@ namespace CreateAR.EnkluPlayer.Test.Scripting
 	public class AnimatorJsApi_Tests
 	{
 		private ElementSchema _schema;
-		private Animator _animator;
-
+		private TestAnimator _animator;
+		
 		private AnimatorJsApi _animatorJsApi;
 		
 		[SetUp]
 		public void Setup()
 		{
 			_schema = new ElementSchema();
-			_animator = new Animator();
+			_animator = new TestAnimator(new AnimatorControllerParameter[]
+			{
+				new AnimatorControllerParameter()
+				{
+					name = "Open",
+					defaultBool = false,
+				},
+				new AnimatorControllerParameter()
+				{
+					name = "Speed",
+					defaultFloat = 0f,
+				},
+				new AnimatorControllerParameter()
+				{
+					name = "Attack",
+					defaultInt = 0,
+				}
+			});
 		}
 
 		[Test]
@@ -29,6 +46,7 @@ namespace CreateAR.EnkluPlayer.Test.Scripting
 			
 			_animatorJsApi = new AnimatorJsApi(_schema, _animator);
 			
+			// Check values from schema were set
 			Assert.AreEqual(true, _animatorJsApi.getBool("Open"));
 			Assert.AreEqual(2.26f, _animatorJsApi.getFloat("Speed"));
 			Assert.AreEqual(2, _animatorJsApi.getInteger("Attack"));
@@ -37,7 +55,27 @@ namespace CreateAR.EnkluPlayer.Test.Scripting
 		[Test]
 		public void NoSchema()
 		{
+			_animatorJsApi = new AnimatorJsApi(_schema, _animator);
 			
+			// Set via API
+			_animatorJsApi.setBool("Open", true);
+			_animatorJsApi.setFloat("Speed", 2.26f);
+			_animatorJsApi.setInteger("Attack", 2);
+			
+			// Verify schema was generated
+			Assert.AreEqual(true, _schema.GetOwn("animator.Open", false).Value);
+			Assert.AreEqual(2.26f, _schema.GetOwn("animator.Speed", 0f).Value);
+			Assert.AreEqual(2, _schema.GetOwn("animator.Attack", 0).Value);
+			
+			// Set via new schema
+			_schema.Set("animator.Open", false);
+			_schema.Set("animator.Speed", 5.42f);
+			_schema.Set("animator.Attack", 4);
+			
+			// Verify API values match schema
+			Assert.AreEqual(false, _animatorJsApi.getBool("Open"));
+			Assert.AreEqual(5.42f, _animatorJsApi.getFloat("Speed"));
+			Assert.AreEqual(4, _animatorJsApi.getInteger("Attack"));
 		}
 	}
 }

--- a/Assets/Editor/Test/Scripting/AnimatorJsApi_Tests.cs.meta
+++ b/Assets/Editor/Test/Scripting/AnimatorJsApi_Tests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e03b835f00c44b04d824a05307ac29a2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/Test/Scripting/AudioJsApi_Tests.cs
+++ b/Assets/Editor/Test/Scripting/AudioJsApi_Tests.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class AudioJsApi_Tests : MonoBehaviour {
+
+	// Use this for initialization
+	void Start () {
+		
+	}
+	
+	// Update is called once per frame
+	void Update () {
+		
+	}
+}

--- a/Assets/Editor/Test/Scripting/AudioJsApi_Tests.cs
+++ b/Assets/Editor/Test/Scripting/AudioJsApi_Tests.cs
@@ -2,8 +2,9 @@
 using CreateAR.EnkluPlayer.Test.Scripting;
 using NUnit.Framework;
 
-namespace CreateAR.EnkluPlayer.Tests.Scripting
+namespace CreateAR.EnkluPlayer.Test.Scripting
 {
+	[TestFixture]
 	public class AudioJsApi_Tests
 	{
 		private ElementSchema _schema;

--- a/Assets/Editor/Test/Scripting/AudioJsApi_Tests.cs
+++ b/Assets/Editor/Test/Scripting/AudioJsApi_Tests.cs
@@ -25,6 +25,7 @@ namespace CreateAR.EnkluPlayer.Test.Scripting
 			_schema.Set("audio.volume", 1f);
 			
 			_audioJsApi = new AudioJsApi(_schema, _audioSource);
+			_audioJsApi.Setup();
 			
 			// Check values from schema were set
 			Assert.AreEqual(1f, _audioSource.Volume);
@@ -34,6 +35,7 @@ namespace CreateAR.EnkluPlayer.Test.Scripting
 		public void NoSchema()
 		{
 			_audioJsApi = new AudioJsApi(_schema, _audioSource);
+			_audioJsApi.Setup();
 
 			// Set via API
 			_audioJsApi.volume = 0.7f;

--- a/Assets/Editor/Test/Scripting/AudioJsApi_Tests.cs
+++ b/Assets/Editor/Test/Scripting/AudioJsApi_Tests.cs
@@ -1,16 +1,50 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using CreateAR.EnkluPlayer.IUX;
+using CreateAR.EnkluPlayer.Test.Scripting;
+using NUnit.Framework;
 
-public class AudioJsApi_Tests : MonoBehaviour {
+namespace CreateAR.EnkluPlayer.Tests.Scripting
+{
+	public class AudioJsApi_Tests
+	{
+		private ElementSchema _schema;
+		private TestAudioSource _audioSource;
+		
+		private AudioJsApi _audioJsApi;
 
-	// Use this for initialization
-	void Start () {
-		
-	}
-	
-	// Update is called once per frame
-	void Update () {
-		
+		[SetUp]
+		public void Setup()
+		{
+			_schema = new ElementSchema();
+			_audioSource = new TestAudioSource();			
+		}
+
+		[Test]
+		public void HasSchema()
+		{
+			_schema.Set("audio.volume", 1f);
+			
+			_audioJsApi = new AudioJsApi(_schema, _audioSource);
+			
+			// Check values from schema were set
+			Assert.AreEqual(1f, _audioSource.Volume);
+		}
+
+		[Test]
+		public void NoSchema()
+		{
+			_audioJsApi = new AudioJsApi(_schema, _audioSource);
+
+			// Set via API
+			_audioJsApi.volume = 0.7f;
+			
+			// Verify schema was generated
+			Assert.AreEqual(0.7f, _schema.GetOwn("audio.volume", 0f).Value);
+			
+			// Set via new schema
+			_schema.Set("audio.volume", 0.2f);
+			
+			// Verify API values match schema
+			Assert.AreEqual(0.2f, _audioJsApi.volume);
+		}
 	}
 }

--- a/Assets/Editor/Test/Scripting/AudioJsApi_Tests.cs.meta
+++ b/Assets/Editor/Test/Scripting/AudioJsApi_Tests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a2cb4d6024967c34ea4359a8f7475d38
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/Test/Scripting/MaterialJsApi_Tests.cs
+++ b/Assets/Editor/Test/Scripting/MaterialJsApi_Tests.cs
@@ -58,15 +58,15 @@ namespace CreateAR.EnkluPlayer.Test.Scripting
             Assert.AreEqual(new Col4(0.1f, 0.2f, 0.3f, 1), _schema.GetOwn("material._Color", Col4.White).Value);
             
             // Test setting via Schema
-            _schema.Set("_Alpha", 0.2f);
-            _schema.Set("_Daytime", 0);
-            _schema.Set("_Center", new Vec3(3, 2, 1));
-            _schema.Set("_Color", new Col4(1, 2, 3, 1));
+            _schema.Set("material._Alpha", 0.2f);
+            _schema.Set("material._Daytime", 0);
+            _schema.Set("material._Center", new Vec3(3, 2, 1));
+            _schema.Set("material._Color", new Col4(1, 2, 3, 1));
             
-            Assert.AreEqual(0.2f, _schema.GetOwn("_Alpha", -1f).Value);
-            Assert.AreEqual(0, _schema.GetOwn("_Daytime", -1).Value);
-            Assert.AreEqual(new Vec3(3, 2, 1), _schema.GetOwn("Center", Vec3.Zero).Value);
-            Assert.AreEqual(new Col4(0.1f, 0.2f, 0.3f, 1), _schema.GetOwn("_Alpha", Col4.White).Value);
+            Assert.AreEqual(0.2f, _materialJsApi.getFloat("_Alpha"));
+            Assert.AreEqual(0, _materialJsApi.getInt("_Daytime"));
+            Assert.AreEqual(new Vec3(3, 2, 1), _materialJsApi.getVector("_Center"));
+            Assert.AreEqual(new Col4(1f, 2f, 3f, 1), _materialJsApi.getColor("_Color"));
         }
     }
 }

--- a/Assets/Editor/Test/Scripting/MaterialJsApi_Tests.cs
+++ b/Assets/Editor/Test/Scripting/MaterialJsApi_Tests.cs
@@ -43,6 +43,7 @@ namespace CreateAR.EnkluPlayer.Test.Scripting
         public void NoSchema()
         {
             _materialJsApi = new MaterialJsApi(_schema, _renderer);
+            _materialJsApi.Setup();
             
             // Test setting via the API
             _materialJsApi.setFloat("_Alpha", 0.9f);

--- a/Assets/Editor/Test/Scripting/MaterialJsApi_Tests.cs
+++ b/Assets/Editor/Test/Scripting/MaterialJsApi_Tests.cs
@@ -1,0 +1,72 @@
+﻿using CreateAR.EnkluPlayer.IUX;
+using CreateAR.EnkluPlayer.Scripting;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace CreateAR.EnkluPlayer.Test.Scripting
+{
+    [TestFixture]
+    public class MaterialJsApi_Tests
+    {
+        private ElementSchema _schema;
+        private IRenderer _renderer;
+        private TestMaterial _material;
+
+        private MaterialJsApi _materialJsApi;
+        
+        [SetUp]
+        public void Setup()
+        {
+            _schema = new ElementSchema();
+            _material = new TestMaterial();
+            _renderer = new TestRenderer(_material);
+        }
+
+        // TODO: Unity 2018.2 upgrade - Enable this test
+//        [Test]
+//        public void HasSchema()
+//        {
+//            _schema.Set("material._Alpha", 0.9f);
+//            _schema.Set("material._Daytime", 1);
+//            _schema.Set("material._Center", new Vec3(1, 2, 3));
+//            _schema.Set("material._Color", new Col4(0.1f, 0.2f, 0.3f, 1));
+//            
+//            _materialJsApi = new MaterialJsApi(_schema, _renderer);
+//
+//            Assert.AreEqual(0.9f, _material.GetFloat("_Alpha"));
+//            Assert.AreEqual(1, _material.GetInt("_Daytime"));
+//            Assert.AreEqual(new Vec3(1, 2, 3), _material.GetVector("_Center"));
+//            Assert.AreEqual(new Col4(0.1f, 0.2f, 0.3f, 1), _material.GetColor("_Color"));
+//        }
+
+        [Test]
+        public void NoSchema()
+        {
+            _materialJsApi = new MaterialJsApi(_schema, _renderer);
+            
+            // Test setting via the API
+            _materialJsApi.setFloat("_Alpha", 0.9f);
+            Assert.AreEqual(0.9f, _schema.GetOwn("material._Alpha", -1f).Value);
+            
+            _materialJsApi.setInt("_Daytime", 1);
+            Assert.AreEqual(1, _schema.GetOwn("material._Daytime", -1).Value);
+            
+            _materialJsApi.setVector("_Center", new Vec3(1, 2, 3));
+            Assert.AreEqual(new Vec3(1, 2, 3), _schema.GetOwn("material._Center", Vec3.Zero).Value);
+            
+            _materialJsApi.setColor("_Color", new Col4(0.1f, 0.2f, 0.3f, 1));
+            Assert.AreEqual(new Col4(0.1f, 0.2f, 0.3f, 1), _schema.GetOwn("material._Color", Col4.White).Value);
+            
+            // Test setting via Schema
+            _schema.Set("_Alpha", 0.2f);
+            _schema.Set("_Daytime", 0);
+            _schema.Set("_Center", new Vec3(3, 2, 1));
+            _schema.Set("_Color", new Col4(1, 2, 3, 1));
+            
+            Assert.AreEqual(0.2f, _schema.GetOwn("_Alpha", -1f).Value);
+            Assert.AreEqual(0, _schema.GetOwn("_Daytime", -1).Value);
+            Assert.AreEqual(new Vec3(3, 2, 1), _schema.GetOwn("Center", Vec3.Zero).Value);
+            Assert.AreEqual(new Col4(0.1f, 0.2f, 0.3f, 1), _schema.GetOwn("_Alpha", Col4.White).Value);
+        }
+    }
+}

--- a/Assets/Editor/Test/Scripting/MaterialJsApi_Tests.cs.meta
+++ b/Assets/Editor/Test/Scripting/MaterialJsApi_Tests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c7acd6b79e5220b4fa3b013286c65ba8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Source/Player/IUX/Element/ElementSchema.cs
+++ b/Assets/Source/Player/IUX/Element/ElementSchema.cs
@@ -414,6 +414,11 @@ namespace CreateAR.EnkluPlayer.IUX
 
             return Default<T>();
         }
+
+        public ElementSchemaProp GetOwn(string name)
+        {
+            return Prop(name);
+        }
         
         /// <summary>
         /// Returns true iff the schema or parent schemas have a property with

--- a/Assets/Source/Player/IUX/Element/ElementSchema.cs
+++ b/Assets/Source/Player/IUX/Element/ElementSchema.cs
@@ -415,6 +415,11 @@ namespace CreateAR.EnkluPlayer.IUX
             return Default<T>();
         }
 
+        /// <summary>
+        /// Returns the prop if locally defined, or null otherwise.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
         public ElementSchemaProp GetOwn(string name)
         {
             return Prop(name);

--- a/Assets/Source/Player/IUX/Element/ElementSchema.cs
+++ b/Assets/Source/Player/IUX/Element/ElementSchema.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Text;
 
 namespace CreateAR.EnkluPlayer.IUX
@@ -414,16 +415,6 @@ namespace CreateAR.EnkluPlayer.IUX
 
             return Default<T>();
         }
-
-        /// <summary>
-        /// Returns the prop if locally defined, or null otherwise.
-        /// </summary>
-        /// <param name="name"></param>
-        /// <returns></returns>
-        public ElementSchemaProp GetOwn(string name)
-        {
-            return Prop(name);
-        }
         
         /// <summary>
         /// Returns true iff the schema or parent schemas have a property with
@@ -471,6 +462,16 @@ namespace CreateAR.EnkluPlayer.IUX
             }
 
             return false;
+        }
+        
+        /// <summary>
+        /// Returns a ReadOnlyCollection of all props specific to this Element.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public ReadOnlyCollection<ElementSchemaProp> GetOwnProps()
+        {
+            return _props.AsReadOnly();
         }
 
         /// <summary>

--- a/Assets/Source/Player/Scripting/IRenderer.cs
+++ b/Assets/Source/Player/Scripting/IRenderer.cs
@@ -1,0 +1,13 @@
+namespace CreateAR.EnkluPlayer.Scripting
+{
+    /// <summary>
+    /// A generic renderer. Copying Unity's naming for now until we need more.
+    /// </summary>
+    public interface IRenderer
+    {
+        /// <summary>
+        /// The shared material used.
+        /// </summary>
+        IMaterial SharedMaterial { get; set; }
+    }
+}

--- a/Assets/Source/Player/Scripting/IRenderer.cs.meta
+++ b/Assets/Source/Player/Scripting/IRenderer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: edbd447d9b9c480eb946b91f99f1db4b
+timeCreated: 1543790724

--- a/Assets/Source/Player/Scripting/Interface/Elements/AnimatorJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/AnimatorJsApi.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using CreateAR.Commons.Unity.Logging;
 using CreateAR.EnkluPlayer.IUX;
 using UnityEngine;
@@ -152,7 +153,7 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// </summary>
         /// <param name="name"></param>
         /// <returns></returns>
-        public int getInteger(string name)
+        public int getInt(string name)
         {
             return _animator.GetInt(name);
         }
@@ -162,7 +163,7 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// </summary>
         /// <param name="name"></param>
         /// <param name="value"></param>
-        public void setInteger(string name, int value)
+        public void setInt(string name, int value)
         {
             var prop = GetSchemaProp(_propsInt, name);
             if (prop == null)
@@ -177,6 +178,30 @@ namespace CreateAR.EnkluPlayer.Scripting
             {
                 prop.Value = value;   
             }
+        }
+
+        /// <summary>
+        /// Gets the current value for a parameter.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        [Obsolete]
+        public int getInteger(string name)
+        {
+            Log.Warning(this, "animator.getInteger is deprecated. Use animator.getInt instead.");
+            return getInt(name);
+        }
+
+        /// <summary>
+        /// Sets the value for a parameter.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="value"></param>
+        [Obsolete]
+        public void setInteger(string name, int value)
+        {
+            Log.Warning(this, "animator.setInteger is deprecated. Use animator.setInt instead.");
+            setInt(name, value);
         }
 
         /// <summary>

--- a/Assets/Source/Player/Scripting/Interface/Elements/AnimatorJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/AnimatorJsApi.cs
@@ -60,6 +60,7 @@ namespace CreateAR.EnkluPlayer.Scripting
                 
                 var prop = _schema.GetOwn(ToSchemaName(_parameterNames[i]));
 
+                // Load defaults if available
                 if (prop != null)
                 {
                     if (prop.Type == typeof(float))
@@ -94,7 +95,7 @@ namespace CreateAR.EnkluPlayer.Scripting
         }
 
         /// <summary>
-        /// Deconstructor
+        /// Destructor.
         /// </summary>
         ~AnimatorJsApi()
         {

--- a/Assets/Source/Player/Scripting/Interface/Elements/AnimatorJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/AnimatorJsApi.cs
@@ -71,43 +71,56 @@ namespace CreateAR.EnkluPlayer.Scripting
             {
                 throw new Exception("AnimatorJsApi already setup.");
             }
+
+            var props = _schema.GetOwnProps();
             
             for (var i = 0; i < _parameterNames.Length; i++)
             {
                 _parameterNames[i] = _animator.Parameters[i].name;
-                
-                var prop = _schema.GetOwn(ToSchemaName(_parameterNames[i]));
 
-                // Load defaults if available
-                if (prop != null)
+                // Find a matching prop
+                ElementSchemaProp prop = null;
+                var schemaName = ToSchemaName(_parameterNames[i]);
+                for (var j = 0; j < props.Count; j++)
                 {
-                    if (prop.Type == typeof(float))
+                    if (props[j].Name == schemaName)
                     {
-                        var propFloat = (ElementSchemaProp<float>) prop;
-                        
-                        _propsFloat.Add(propFloat);
-                        propFloat.OnChanged += Prop_OnFloatChanged;
-                        
-                        _animator.SetFloat(_parameterNames[i], propFloat.Value);
-                    } 
-                    else if (prop.Type == typeof(int))
-                    {
-                        var propInt = (ElementSchemaProp<int>) prop;
-                        
-                        _propsInt.Add(propInt);
-                        propInt.OnChanged += Prop_OnIntChanged;
-                        
-                        _animator.SetInt(_parameterNames[i], propInt.Value);
+                        prop = props[j];
                     }
-                    else if (prop.Type == typeof(bool))
-                    {
-                        var propBool = (ElementSchemaProp<bool>) prop;
+                }
+
+                if (prop == null)
+                {
+                    continue;
+                }
+
+                // Load defaults
+                if (prop.Type == typeof(float))
+                {
+                    var propFloat = (ElementSchemaProp<float>) prop;
                         
-                        _propsBool.Add(propBool);
-                        propBool.OnChanged += Prop_OnBoolChanged;
+                    _propsFloat.Add(propFloat);
+                    propFloat.OnChanged += Prop_OnFloatChanged;
                         
-                        _animator.SetBool(_parameterNames[i], propBool.Value);
-                    }
+                    _animator.SetFloat(_parameterNames[i], propFloat.Value);
+                } 
+                else if (prop.Type == typeof(int))
+                {
+                    var propInt = (ElementSchemaProp<int>) prop;
+                        
+                    _propsInt.Add(propInt);
+                    propInt.OnChanged += Prop_OnIntChanged;
+                        
+                    _animator.SetInt(_parameterNames[i], propInt.Value);
+                }
+                else if (prop.Type == typeof(bool))
+                {
+                    var propBool = (ElementSchemaProp<bool>) prop;
+                        
+                    _propsBool.Add(propBool);
+                    propBool.OnChanged += Prop_OnBoolChanged;
+                        
+                    _animator.SetBool(_parameterNames[i], propBool.Value);
                 }
             }
 

--- a/Assets/Source/Player/Scripting/Interface/Elements/AudioJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/AudioJsApi.cs
@@ -24,60 +24,7 @@ namespace CreateAR.EnkluPlayer
         /// Tracks whether Setup has been called.
         /// </summary>
         private bool _setup;
-
-        /// <summary>
-        /// Constructor
-        /// </summary>
-        /// <param name="schema"></param>
-        /// <param name="audio"></param>
-        public AudioJsApi(ElementSchema schema, IAudioSource audio)
-        {
-            _audio = audio;
-
-            _volumeProp = schema.GetOwn<float>("audio.volume", -1);
-        }
-
-        /// <summary>
-        /// Subscribes to schema.
-        /// </summary>
-        public void Setup()
-        {
-            if (_setup)
-            {
-                throw new Exception("AudioJsApi already setup.");
-            }
-            
-            if (_volumeProp.Value >= 0)
-            {
-                // Set initial
-                Volume_OnChanged(_volumeProp, _volumeProp.Value, _volumeProp.Value);
-            }
-            else
-            {
-                // Load from prefab
-                _volumeProp.Value = volume;
-            }
-
-            _volumeProp.OnChanged += Volume_OnChanged;
-
-            _setup = true;
-        }
-
-        /// <summary>
-        /// Unsubscribes from schema.
-        /// </summary>
-        public void Teardown()
-        {
-            if (!_setup)
-            {
-                throw new Exception("AudioJsApi not setup.");
-            }
-            
-            _volumeProp.OnChanged -= Volume_OnChanged;
-
-            _setup = false;
-        }
-
+        
         /// <summary>
         /// Volume.
         /// </summary>
@@ -148,6 +95,59 @@ namespace CreateAR.EnkluPlayer
         {
             get { return _audio.DopplerLevel; }
             set { _audio.DopplerLevel = value; }
+        }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="schema"></param>
+        /// <param name="audio"></param>
+        public AudioJsApi(ElementSchema schema, IAudioSource audio)
+        {
+            _audio = audio;
+
+            _volumeProp = schema.GetOwn<float>("audio.volume", -1);
+        }
+
+        /// <summary>
+        /// Subscribes to schema.
+        /// </summary>
+        public void Setup()
+        {
+            if (_setup)
+            {
+                throw new Exception("AudioJsApi already setup.");
+            }
+            
+            if (_volumeProp.Value >= 0)
+            {
+                // Set initial
+                Volume_OnChanged(_volumeProp, _volumeProp.Value, _volumeProp.Value);
+            }
+            else
+            {
+                // Load from prefab
+                _volumeProp.Value = volume;
+            }
+
+            _volumeProp.OnChanged += Volume_OnChanged;
+
+            _setup = true;
+        }
+
+        /// <summary>
+        /// Unsubscribes from schema.
+        /// </summary>
+        public void Teardown()
+        {
+            if (!_setup)
+            {
+                throw new Exception("AudioJsApi not setup.");
+            }
+            
+            _volumeProp.OnChanged -= Volume_OnChanged;
+
+            _setup = false;
         }
 
         /// <summary>

--- a/Assets/Source/Player/Scripting/Interface/Elements/AudioJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/AudioJsApi.cs
@@ -1,4 +1,5 @@
 ﻿using CreateAR.EnkluPlayer.IUX;
+using CreateAR.EnkluPlayer.Scripting;
 using UnityEngine;
 
 namespace CreateAR.EnkluPlayer
@@ -11,8 +12,11 @@ namespace CreateAR.EnkluPlayer
         /// <summary>
         /// Underlying AudioSource to wrap.
         /// </summary>
-        private readonly AudioSource _audio;
+        private readonly IAudioSource _audio;
 
+        /// <summary>
+        /// Backing Schema prop.
+        /// </summary>
         private readonly ElementSchemaProp<float> _volumeProp;
 
         /// <summary>
@@ -20,7 +24,7 @@ namespace CreateAR.EnkluPlayer
         /// </summary>
         /// <param name="schema"></param>
         /// <param name="audio"></param>
-        public AudioJsApi(ElementSchema schema, AudioSource audio)
+        public AudioJsApi(ElementSchema schema, IAudioSource audio)
         {
             _audio = audio;
 
@@ -28,10 +32,12 @@ namespace CreateAR.EnkluPlayer
             
             if (_volumeProp.Value >= 0)
             {
-                volume = _volumeProp.Value;
+                // Set initial
+                OnVolumeChanged(_volumeProp, _volumeProp.Value, _volumeProp.Value);
             }
             else
             {
+                // Load from prefab
                 _volumeProp.Value = volume;
             }
 
@@ -57,8 +63,8 @@ namespace CreateAR.EnkluPlayer
         /// </summary>
         public bool loop
         {
-            get { return _audio.loop; }
-            set { _audio.loop = value; }
+            get { return _audio.Loop; }
+            set { _audio.Loop = value; }
         }
 
         /// <summary>
@@ -66,8 +72,8 @@ namespace CreateAR.EnkluPlayer
         /// </summary>
         public bool mute
         {
-            get { return _audio.mute; }
-            set { _audio.mute = value; }
+            get { return _audio.Mute; }
+            set { _audio.Mute = value; }
         }
 
         /// <summary>
@@ -75,8 +81,8 @@ namespace CreateAR.EnkluPlayer
         /// </summary>
         public bool playOnAwake
         {
-            get { return _audio.playOnAwake; }
-            set { _audio.playOnAwake = value; }
+            get { return _audio.PlayOnAwake; }
+            set { _audio.PlayOnAwake = value; }
         }
 
         /// <summary>
@@ -84,8 +90,8 @@ namespace CreateAR.EnkluPlayer
         /// </summary>
         public float spatialBlend
         {
-            get { return _audio.spatialBlend; }
-            set { _audio.spatialBlend = value; }
+            get { return _audio.SpatialBlend; }
+            set { _audio.SpatialBlend = value; }
         }
 
         /// <summary>
@@ -93,8 +99,8 @@ namespace CreateAR.EnkluPlayer
         /// </summary>
         public float minDistance
         {
-            get { return _audio.minDistance; }
-            set { _audio.minDistance = value; }
+            get { return _audio.MinDistance; }
+            set { _audio.MinDistance = value; }
         }
 
         /// <summary>
@@ -102,8 +108,8 @@ namespace CreateAR.EnkluPlayer
         /// </summary>
         public float maxDistance
         {
-            get { return _audio.maxDistance; }
-            set { _audio.maxDistance = value; }
+            get { return _audio.MaxDistance; }
+            set { _audio.MaxDistance = value; }
         }
 
         /// <summary>
@@ -111,8 +117,8 @@ namespace CreateAR.EnkluPlayer
         /// </summary>
         public float dopplerLevel
         {
-            get { return _audio.dopplerLevel; }
-            set { _audio.dopplerLevel = value; }
+            get { return _audio.DopplerLevel; }
+            set { _audio.DopplerLevel = value; }
         }
 
         /// <summary>
@@ -120,7 +126,7 @@ namespace CreateAR.EnkluPlayer
         /// </summary>
         private void OnVolumeChanged(ElementSchemaProp<float> prop, float prev, float @new)
         {
-            _audio.volume = @new;
+            _audio.Volume = @new;
         }
     }
 }

--- a/Assets/Source/Player/Scripting/Interface/Elements/AudioJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/AudioJsApi.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using CreateAR.EnkluPlayer.IUX;
+using UnityEngine;
 
 namespace CreateAR.EnkluPlayer
 {
@@ -12,13 +13,34 @@ namespace CreateAR.EnkluPlayer
         /// </summary>
         private readonly AudioSource _audio;
 
+        private readonly ElementSchemaProp<float> _volumeProp;
+
         /// <summary>
         /// Constructor
         /// </summary>
+        /// <param name="schema"></param>
         /// <param name="audio"></param>
-        public AudioJsApi(AudioSource audio)
+        public AudioJsApi(ElementSchema schema, AudioSource audio)
         {
             _audio = audio;
+
+            _volumeProp = schema.GetOwn<float>("audio.volume", -1);
+            
+            if (_volumeProp.Value >= 0)
+            {
+                volume = _volumeProp.Value;
+            }
+            else
+            {
+                _volumeProp.Value = volume;
+            }
+
+            _volumeProp.OnChanged += OnVolumeChanged;
+        }
+
+        ~AudioJsApi()
+        {
+            _volumeProp.OnChanged -= OnVolumeChanged;
         }
 
         /// <summary>
@@ -26,8 +48,8 @@ namespace CreateAR.EnkluPlayer
         /// </summary>
         public float volume
         {
-            get { return _audio.volume; }
-            set { _audio.volume = value; }
+            get { return _volumeProp.Value; }
+            set { _volumeProp.Value = value; }
         }
 
         /// <summary>
@@ -91,6 +113,14 @@ namespace CreateAR.EnkluPlayer
         {
             get { return _audio.dopplerLevel; }
             set { _audio.dopplerLevel = value; }
+        }
+
+        /// <summary>
+        /// Invoked when the volume changes via schema.
+        /// </summary>
+        private void OnVolumeChanged(ElementSchemaProp<float> prop, float prev, float @new)
+        {
+            _audio.volume = @new;
         }
     }
 }

--- a/Assets/Source/Player/Scripting/Interface/Elements/AudioJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/AudioJsApi.cs
@@ -44,6 +44,9 @@ namespace CreateAR.EnkluPlayer
             _volumeProp.OnChanged += OnVolumeChanged;
         }
 
+        /// <summary>
+        /// Destructor.
+        /// </summary>
         ~AudioJsApi()
         {
             _volumeProp.OnChanged -= OnVolumeChanged;

--- a/Assets/Source/Player/Scripting/Interface/Elements/ContentWidgetJs.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/ContentWidgetJs.cs
@@ -88,7 +88,8 @@ namespace CreateAR.EnkluPlayer.Scripting
             var unityAudioSource = contentWidget.GetComponent<AudioSource>();
             if (unityAudioSource != null)
             {
-                audio = new AudioJsApi(_element.Schema, unityAudioSource);
+                var audioSource = new UnityAudioSource(unityAudioSource);
+                audio = new AudioJsApi(_element.Schema, audioSource);
             }
             else
             {

--- a/Assets/Source/Player/Scripting/Interface/Elements/ContentWidgetJs.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/ContentWidgetJs.cs
@@ -66,7 +66,8 @@ namespace CreateAR.EnkluPlayer.Scripting
             var unityAnimator = contentWidget.GetComponent<Animator>();
             if (unityAnimator != null) 
             {
-                animator = new AnimatorJsApi(_element.Schema, unityAnimator);
+                var anim = new UnityAnimator(unityAnimator);
+                animator = new AnimatorJsApi(_element.Schema, anim);
             }
             else
             {

--- a/Assets/Source/Player/Scripting/Interface/Elements/ContentWidgetJs.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/ContentWidgetJs.cs
@@ -63,33 +63,54 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// </summary>
         private void CacheComponents(ContentWidget contentWidget)
         {
+            // Animator
+            if (animator != null)
+            {
+                animator.Teardown();
+            }
+            
             var unityAnimator = contentWidget.GetComponent<Animator>();
             if (unityAnimator != null) 
             {
                 var anim = new UnityAnimator(unityAnimator);
                 animator = new AnimatorJsApi(_element.Schema, anim);
+                animator.Setup();
             }
             else
             {
                 animator = null;
             }
-
+            
+            // Material
+            if (material != null)
+            {
+                material.Teardown();
+            }
+            
             var unityRenderer = contentWidget.GetComponent<Renderer>();
             if (unityRenderer != null && unityRenderer.sharedMaterial != null)
             {
                 var renderer = new UnityRenderer(unityRenderer); 
                 material = new MaterialJsApi(_element.Schema, renderer);
+                material.Setup();
             }
             else
             {
                 material = null;
             }
 
+            // Audio
+            if (audio != null)
+            {
+                audio.Teardown();
+            }
+            
             var unityAudioSource = contentWidget.GetComponent<AudioSource>();
             if (unityAudioSource != null)
             {
                 var audioSource = new UnityAudioSource(unityAudioSource);
                 audio = new AudioJsApi(_element.Schema, audioSource);
+                audio.Setup();
             }
             else
             {

--- a/Assets/Source/Player/Scripting/Interface/Elements/ContentWidgetJs.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/ContentWidgetJs.cs
@@ -66,7 +66,7 @@ namespace CreateAR.EnkluPlayer.Scripting
             var unityAnimator = contentWidget.GetComponent<Animator>();
             if (unityAnimator != null) 
             {
-                animator = new AnimatorJsApi(unityAnimator);
+                animator = new AnimatorJsApi(_element.Schema, unityAnimator);
             }
             else
             {
@@ -76,7 +76,8 @@ namespace CreateAR.EnkluPlayer.Scripting
             var unityRenderer = contentWidget.GetComponent<Renderer>();
             if (unityRenderer != null && unityRenderer.sharedMaterial != null)
             {
-                material = new MaterialJsApi(unityRenderer);
+                var renderer = new UnityRenderer(unityRenderer); 
+                material = new MaterialJsApi(_element.Schema, renderer);
             }
             else
             {
@@ -86,7 +87,7 @@ namespace CreateAR.EnkluPlayer.Scripting
             var unityAudioSource = contentWidget.GetComponent<AudioSource>();
             if (unityAudioSource != null)
             {
-                audio = new AudioJsApi(unityAudioSource);
+                audio = new AudioJsApi(_element.Schema, unityAudioSource);
             }
             else
             {

--- a/Assets/Source/Player/Scripting/Interface/Elements/MaterialJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/MaterialJsApi.cs
@@ -72,6 +72,16 @@ namespace CreateAR.EnkluPlayer.Scripting
         }
 
         /// <summary>
+        /// Gets a float material property.
+        /// </summary>
+        /// <param name="param"></param>
+        /// <returns></returns>
+        public float getFloat(string param)
+        {
+            return _renderer.SharedMaterial.GetFloat(param);
+        }
+
+        /// <summary>
         /// Sets a float material property.
         /// </summary>
         /// <param name="param"></param>
@@ -91,6 +101,16 @@ namespace CreateAR.EnkluPlayer.Scripting
             {
                 prop.Value = value;
             }
+        }
+
+        /// <summary>
+        /// Gets an integer material property.
+        /// </summary>
+        /// <param name="param"></param>
+        /// <returns></returns>
+        public int getInt(string param)
+        {
+            return _renderer.SharedMaterial.GetInt(param);
         }
 
         /// <summary>
@@ -116,6 +136,16 @@ namespace CreateAR.EnkluPlayer.Scripting
         }
 
         /// <summary>
+        /// Gets a Vec3 for a Vector material property.
+        /// </summary>
+        /// <param name="param"></param>
+        /// <returns></returns>
+        public Vec3 getVector(string param)
+        {
+            return _renderer.SharedMaterial.GetVec3(param);
+        }
+
+        /// <summary>
         /// Sets a Vector material property with a Vec3.
         /// </summary>
         /// <param name="param"></param>
@@ -138,8 +168,17 @@ namespace CreateAR.EnkluPlayer.Scripting
         }
 
         /// <summary>
-        /// Sets a Vector material property with a Vec3 & alpha.
-        /// TODO: Add in a Vec4 and use that instead.
+        /// Gets a Col4 for a Vector material property.
+        /// </summary>
+        /// <param name="param"></param>
+        /// <returns></returns>
+        public Col4 getColor(string param)
+        {
+            return _renderer.SharedMaterial.GetCol4(param);
+        }
+
+        /// <summary>
+        /// Sets a Vector material property with a Col4.
         /// </summary>
         /// <param name="param"></param>
         /// <param name="value"></param>

--- a/Assets/Source/Player/Scripting/Interface/Elements/MaterialJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/MaterialJsApi.cs
@@ -1,4 +1,6 @@
-﻿using UnityEngine;
+﻿using System.Collections.Generic;
+using CreateAR.EnkluPlayer.IUX;
+using UnityEngine;
 
 namespace CreateAR.EnkluPlayer.Scripting
 {
@@ -9,17 +11,64 @@ namespace CreateAR.EnkluPlayer.Scripting
     public class MaterialJsApi
     {
         /// <summary>
+        /// Schema to back shader properties.
+        /// </summary>
+        private readonly ElementSchema _schema;
+        
+        /// <summary>
         /// Underlying Unity Renderer to modify.
         /// </summary>
-        private readonly Renderer _renderer;
+        private readonly IRenderer _renderer;
+
+        /// <summary>
+        /// Backing schema props
+        /// </summary>
+        private readonly List<ElementSchemaProp<float>> _propsFloat;
+        private readonly List<ElementSchemaProp<int>> _propsInt;
+        private readonly List<ElementSchemaProp<Vec3>> _propsVec3;
+        private readonly List<ElementSchemaProp<Col4>> _propsCol4;
 
         /// <summary>
         /// Constructor.
         /// </summary>
+        /// <param name="schema"></param>
         /// <param name="renderer"></param>
-        public MaterialJsApi(Renderer renderer)
+        public MaterialJsApi(ElementSchema schema, IRenderer renderer)
         {
+            _schema = schema;
             _renderer = renderer;
+
+            // TODO: Unity 2018.2 upgrade - Look at Material.GetTexturePropertyNames for setting defaults?!
+            _propsFloat = new List<ElementSchemaProp<float>>();
+            _propsInt = new List<ElementSchemaProp<int>>();
+            _propsVec3 = new List<ElementSchemaProp<Vec3>>();
+            _propsCol4 = new List<ElementSchemaProp<Col4>>();
+        }
+
+        /// <summary>
+        /// Deconstructor
+        /// </summary>
+        ~MaterialJsApi()
+        {
+            for (int i = 0, len = _propsFloat.Count; i < len; i++)
+            {
+                _propsFloat[i].OnChanged -= OnSchemaFloatChange;
+            }
+            
+            for (int i = 0, len = _propsInt.Count; i < len; i++)
+            {
+                _propsInt[i].OnChanged -= OnSchemaIntChange;
+            }
+            
+            for (int i = 0, len = _propsVec3.Count; i < len; i++)
+            {
+                _propsVec3[i].OnChanged -= OnSchemaVectorChange;
+            }
+            
+            for (int i = 0, len = _propsCol4.Count; i < len; i++)
+            {
+                _propsCol4[i].OnChanged -= OnSchemaColorChange;
+            }
         }
 
         /// <summary>
@@ -29,7 +78,19 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// <param name="value"></param>
         public void setFloat(string param, float value)
         {
-            _renderer.sharedMaterial.SetFloat(param, value);
+            var prop = GetSchemaProp(_propsFloat, param);
+            if (prop == null)
+            {
+                prop = _schema.GetOwn(ToSchemaName(param), value);
+                _propsFloat.Add(prop);
+                
+                prop.OnChanged += OnSchemaFloatChange;
+                OnSchemaFloatChange(prop, value, value);
+            }
+            else
+            {
+                prop.Value = value;
+            }
         }
 
         /// <summary>
@@ -39,7 +100,19 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// <param name="value"></param>
         public void setInt(string param, int value)
         {
-            _renderer.sharedMaterial.SetInt(param, value);
+            var prop = GetSchemaProp(_propsInt, param);
+            if (prop == null)
+            {
+                prop = _schema.GetOwn(ToSchemaName(param), value);
+                _propsInt.Add(prop);
+                
+                prop.OnChanged += OnSchemaIntChange;
+                OnSchemaIntChange(prop, value, value);
+            }
+            else
+            {
+                prop.Value = value;
+            }
         }
 
         /// <summary>
@@ -49,7 +122,19 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// <param name="value"></param>
         public void setVector(string param, Vec3 value)
         {
-            _renderer.sharedMaterial.SetVector(param, value.ToVector());
+            var prop = GetSchemaProp(_propsVec3, param);
+            if (prop == null)
+            {
+                prop = _schema.GetOwn(ToSchemaName(param), value);
+                _propsVec3.Add(prop);
+                
+                prop.OnChanged += OnSchemaVectorChange;
+                OnSchemaVectorChange(prop, value, value);
+            }
+            else
+            {
+                prop.Value = value;
+            }
         }
 
         /// <summary>
@@ -58,22 +143,107 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// </summary>
         /// <param name="param"></param>
         /// <param name="value"></param>
-        /// <param name="alpha"></param>
-        public void setVector(string param, Vec3 value, float alpha)
+        public void setColor(string param, Col4 value)
         {
-            _renderer.sharedMaterial.SetVector(
-                param, 
-                new Vector4(value.x, value.y, value.z, alpha));
+            var prop = GetSchemaProp(_propsCol4, param);
+            if (prop == null)
+            {
+                prop = _schema.GetOwn(ToSchemaName(param), value);
+                _propsCol4.Add(prop);
+                
+                prop.OnChanged += OnSchemaColorChange;
+                OnSchemaColorChange(prop, value, value);
+            }
+            else
+            {
+                prop.Value = value;
+            }
+        }
+        
+        /// <summary>
+        /// Converts a schema name to a parameter name.
+        /// </summary>
+        /// <param name="schema"></param>
+        /// <returns></returns>
+        private string FromSchemaName(string schema)
+        {
+            return schema.Substring(schema.IndexOf('.') + 1);
         }
 
         /// <summary>
-        /// Sets a named shader pass enabled/disabled.
+        /// Converts a parameter name to a schema name.
         /// </summary>
-        /// <param name="pass"></param>
-        /// <param name="enabled"></param>
-        public void setShaderPass(string pass, bool enabled)
+        /// <param name="param"></param>
+        /// <returns></returns>
+        private string ToSchemaName(string param)
         {
-            _renderer.sharedMaterial.SetShaderPassEnabled(pass, enabled);
+            return "material." + param;
+        }
+
+        /// <summary>
+        /// Update the underlying material based on schema changes.
+        /// </summary>
+        /// <param name="prop"></param>
+        /// <param name="prev"></param>
+        /// <param name="new"></param>
+        private void OnSchemaFloatChange(ElementSchemaProp<float> prop, float prev, float @new)
+        {
+            _renderer.SharedMaterial.SetFloat(FromSchemaName(prop.Name), @new);
+        }
+        
+        /// <summary>
+        /// Update the underlying material based on schema changes.
+        /// </summary>
+        /// <param name="prop"></param>
+        /// <param name="prev"></param>
+        /// <param name="new"></param>
+        private void OnSchemaIntChange(ElementSchemaProp<int> prop, int prev, int @new)
+        {
+            _renderer.SharedMaterial.SetInt(FromSchemaName(prop.Name), @new);
+        }
+        
+        /// <summary>
+        /// Update the underlying material based on schema changes.
+        /// </summary>
+        /// <param name="prop"></param>
+        /// <param name="prev"></param>
+        /// <param name="new"></param>
+        private void OnSchemaVectorChange(ElementSchemaProp<Vec3> prop, Vec3 prev, Vec3 @new)
+        {
+            _renderer.SharedMaterial.SetVec3(FromSchemaName(prop.Name), @new);
+        }
+        
+        /// <summary>
+        /// Update the underlying material based on schema changes.
+        /// </summary>
+        /// <param name="prop"></param>
+        /// <param name="prev"></param>
+        /// <param name="new"></param>
+        private void OnSchemaColorChange(ElementSchemaProp<Col4> prop, Col4 prev, Col4 @new)
+        {
+            _renderer.SharedMaterial.SetCol4(FromSchemaName(prop.Name), @new);
+        }
+
+        /// <summary>
+        /// Gets an ElementSchemaProp by name.
+        /// </summary>
+        /// <param name="props"></param>
+        /// <param name="param"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        private ElementSchemaProp<T> GetSchemaProp<T>(List<ElementSchemaProp<T>> props, string param)
+        {
+            var schemaName = ToSchemaName(param);
+            
+            for (int i = 0, len = props.Count; i < len; i++)
+            {
+                if (props[i].Name == schemaName)
+                {
+                    return props[i];
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/Assets/Source/Player/Scripting/Interface/Elements/MaterialJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/MaterialJsApi.cs
@@ -46,7 +46,7 @@ namespace CreateAR.EnkluPlayer.Scripting
         }
 
         /// <summary>
-        /// Deconstructor
+        /// Destructor.
         /// </summary>
         ~MaterialJsApi()
         {

--- a/Assets/Source/Player/Scripting/Interface/IAnimator.cs
+++ b/Assets/Source/Player/Scripting/Interface/IAnimator.cs
@@ -1,0 +1,7 @@
+namespace CreateAR.EnkluPlayer.Scripting
+{
+    public interface IAnimator
+    {
+        
+    }
+}

--- a/Assets/Source/Player/Scripting/Interface/IAnimator.cs
+++ b/Assets/Source/Player/Scripting/Interface/IAnimator.cs
@@ -1,7 +1,72 @@
+using UnityEngine;
+
 namespace CreateAR.EnkluPlayer.Scripting
 {
+    /// <summary>
+    /// Interface for an Animator.
+    /// </summary>
     public interface IAnimator
     {
+        /// <summary>
+        /// Parameters for this animator.
+        /// </summary>
+        AnimatorControllerParameter[] Parameters { get; }
+
+        /// <summary>
+        /// Gets a bool parameter.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        bool GetBool(string name);
         
+        /// <summary>
+        /// Sets a bool parameter.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="value"></param>
+        void SetBool(string name, bool value);
+
+        /// <summary>
+        /// Gets an int parameter.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        int GetInt(string name);
+        
+        /// <summary>
+        /// Sets an int parameter.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="value"></param>
+        void SetInt(string name, int value);
+
+        /// <summary>
+        /// Gets a float parameter.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        float GetFloat(string name);
+        
+        /// <summary>
+        /// Sets a float parameter.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="value"></param>
+        void SetFloat(string name, float value);
+
+        /// <summary>
+        /// Gets the current playing clip name.
+        /// </summary>
+        /// <param name="layer"></param>
+        /// <returns></returns>
+        string CurrentClipName(int layer = 0);
+        
+        /// <summary>
+        /// Returns true if clipName is currently playing.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="layer"></param>
+        /// <returns></returns>
+        bool IsClipPlaying(string clipName, int layer = 0);
     }
 }

--- a/Assets/Source/Player/Scripting/Interface/IAnimator.cs.meta
+++ b/Assets/Source/Player/Scripting/Interface/IAnimator.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ff5e9004deb2479dba4c1b30d9e7a2f2
+timeCreated: 1543630825

--- a/Assets/Source/Player/Scripting/Interface/IAudioSource.cs
+++ b/Assets/Source/Player/Scripting/Interface/IAudioSource.cs
@@ -1,0 +1,48 @@
+namespace CreateAR.EnkluPlayer.Scripting
+{
+    /// <summary>
+    /// Representation of an Audio source.
+    /// </summary>
+    public interface IAudioSource
+    {
+        /// <summary>
+        /// The volume the source uses.
+        /// </summary>
+        float Volume { get; set; }
+        
+        /// <summary>
+        /// Loop.
+        /// </summary>
+        bool Loop { get; set; }
+        
+        /// <summary>
+        /// Mute.
+        /// </summary>
+        bool Mute { get; set; }
+        
+        /// <summary>
+        /// Whether the audio plays on awake or not.
+        /// </summary>
+        bool PlayOnAwake { get; set; }
+        
+        /// <summary>
+        /// Spatial Blend. 0: 2D, 1:3D
+        /// </summary>
+        float SpatialBlend { get; set; }
+        
+        /// <summary>
+        /// Minimum distance.
+        /// </summary>
+        float MinDistance { get; set; }
+        
+        /// <summary>
+        /// Maximum distance.
+        /// </summary>
+        float MaxDistance { get; set; }
+        
+        /// <summary>
+        /// Doppler level.
+        /// </summary>
+        float DopplerLevel { get; set; }
+    }
+}

--- a/Assets/Source/Player/Scripting/Interface/IAudioSource.cs.meta
+++ b/Assets/Source/Player/Scripting/Interface/IAudioSource.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: aef0f08422a6430fb6673b71aeb442e8
+timeCreated: 1543870335

--- a/Assets/Source/Player/Scripting/Interface/IMaterial.cs
+++ b/Assets/Source/Player/Scripting/Interface/IMaterial.cs
@@ -1,0 +1,64 @@
+namespace CreateAR.EnkluPlayer.Scripting
+{
+    /// <summary>
+    /// A Material.
+    /// </summary>
+    public interface IMaterial
+    {
+        /// <summary>
+        /// Get a float by name.
+        /// </summary>
+        /// <param name="param"></param>
+        /// <returns></returns>
+        float GetFloat(string param);
+        
+        /// <summary>
+        /// Set a float by name.
+        /// </summary>
+        /// <param name="param"></param>
+        /// <param name="value"></param>
+        void SetFloat(string param, float value);
+        
+        /// <summary>
+        /// Get an int by name.
+        /// </summary>
+        /// <param name="param"></param>
+        /// <returns></returns>
+        int GetInt(string param);
+        
+        /// <summary>
+        /// Set an int by name.
+        /// </summary>
+        /// <param name="param"></param>
+        /// <param name="value"></param>
+        void SetInt(string param, int value);
+
+        /// <summary>
+        /// Get a Vec3 by name.
+        /// </summary>
+        /// <param name="param"></param>
+        /// <returns></returns>
+        Vec3 GetVec3(string param);
+        
+        /// <summary>
+        /// Set a Vec3 by name.
+        /// </summary>
+        /// <param name="param"></param>
+        /// <param name="value"></param>
+        void SetVec3(string param, Vec3 value);
+
+        /// <summary>
+        /// Get a Col4 by name.
+        /// </summary>
+        /// <param name="param"></param>
+        /// <returns></returns>
+        Col4 GetCol4(string param);
+        
+        /// <summary>
+        /// Set a Col4 by name.
+        /// </summary>
+        /// <param name="param"></param>
+        /// <param name="value"></param>
+        void SetCol4(string param, Col4 value);
+    }
+}

--- a/Assets/Source/Player/Scripting/Interface/IMaterial.cs.meta
+++ b/Assets/Source/Player/Scripting/Interface/IMaterial.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 31f1984198e045c1bb71744223b89d65
+timeCreated: 1543630799

--- a/Assets/Source/Player/Scripting/Interface/UnityAnimator.cs
+++ b/Assets/Source/Player/Scripting/Interface/UnityAnimator.cs
@@ -1,0 +1,88 @@
+using UnityEngine;
+
+namespace CreateAR.EnkluPlayer.Scripting
+{
+    /// <summary>
+    /// IAnimator implementation for Unity.
+    /// </summary>
+    public class UnityAnimator : IAnimator
+    {
+        /// <summary>
+        /// Backing Unity Animator.
+        /// </summary>
+        private Animator _animator;
+        
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="animator"></param>
+        public UnityAnimator(Animator animator)
+        {
+            _animator = animator;
+        }
+
+        /// <inheritdoc />
+        public AnimatorControllerParameter[] Parameters
+        {
+            get { return _animator.parameters; }
+        }
+
+        /// <inheritdoc />
+        public bool GetBool(string name)
+        {
+            return _animator.GetBool(name);
+        }
+
+        /// <inheritdoc />
+        public void SetBool(string name, bool value)
+        {
+            _animator.SetBool(name, value);
+        }
+
+        /// <inheritdoc />
+        public int GetInt(string name)
+        {
+            return _animator.GetInteger(name);
+        }
+
+        /// <inheritdoc />
+        public void SetInt(string name, int value)
+        {
+            _animator.SetInteger(name, value);
+        }
+
+        /// <inheritdoc />
+        public float GetFloat(string name)
+        {
+            return _animator.GetFloat(name);
+        }
+
+        /// <inheritdoc />
+        public void SetFloat(string name, float value)
+        {
+            _animator.SetFloat(name, value);
+        }
+
+        /// <inheritdoc />
+        public string CurrentClipName(int layer = 0)
+        {
+            return _animator.GetCurrentAnimatorClipInfo(layer)[0].clip.name;
+        }
+
+        /// <inheritdoc />
+        public bool IsClipPlaying(string clipName, int layer = 0)
+        {
+            var clips = _animator.GetCurrentAnimatorClipInfo(layer);
+            
+            for (var i = 0; i < clips.Length; i++)
+            {
+                if (clips[i].clip.name == clipName)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Assets/Source/Player/Scripting/Interface/UnityAnimator.cs.meta
+++ b/Assets/Source/Player/Scripting/Interface/UnityAnimator.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 82f2d0b1ee2b404d9c7ed13147ef66a7
+timeCreated: 1543866732

--- a/Assets/Source/Player/Scripting/Interface/UnityAudioSource.cs
+++ b/Assets/Source/Player/Scripting/Interface/UnityAudioSource.cs
@@ -1,0 +1,80 @@
+using UnityEngine;
+
+namespace CreateAR.EnkluPlayer.Scripting
+{
+    /// <summary>
+    /// Unity implementation of IAudioSource.
+    /// </summary>
+    public class UnityAudioSource : IAudioSource
+    {
+        /// <summary>
+        /// Underlying Unity AudioSource.
+        /// </summary>
+        private AudioSource _audioSource;
+
+        /// <inheritdoc />
+        public float Volume
+        {
+            get { return _audioSource.volume; }
+            set { _audioSource.volume = value; }
+        }
+
+        /// <inheritdoc />
+        public bool Loop
+        {
+            get { return _audioSource.loop; }
+            set { _audioSource.loop = value; }
+        }
+
+        /// <inheritdoc />
+        public bool Mute
+        {
+            get { return _audioSource.mute; }
+            set { _audioSource.mute = value; }
+        }
+
+        /// <inheritdoc />
+        public bool PlayOnAwake
+        {
+            get { return _audioSource.playOnAwake; }
+            set { _audioSource.playOnAwake = value; }
+        }
+        
+        /// <inheritdoc />
+        public float SpatialBlend
+        {
+            get { return _audioSource.spatialBlend; }
+            set { _audioSource.spatialBlend = value; }
+        }
+        
+        /// <inheritdoc />
+        public float MinDistance
+        {
+            get { return _audioSource.minDistance; }
+            set { _audioSource.minDistance = value; }
+        }
+        
+        /// <inheritdoc />
+        public float MaxDistance
+        {
+            get { return _audioSource.maxDistance; }
+            set { _audioSource.maxDistance = value; }
+        }
+        
+        /// <inheritdoc />
+        public float DopplerLevel
+        {
+            get { return _audioSource.dopplerLevel; }
+            set { _audioSource.dopplerLevel = value; }
+        }
+        
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="audioSource"></param>
+        public UnityAudioSource(AudioSource audioSource)
+        {
+            _audioSource = audioSource;
+        }
+    }
+}

--- a/Assets/Source/Player/Scripting/Interface/UnityAudioSource.cs.meta
+++ b/Assets/Source/Player/Scripting/Interface/UnityAudioSource.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c4c145b126494e69b12d82568c855095
+timeCreated: 1543870431

--- a/Assets/Source/Player/Scripting/Interface/UnityMaterial.cs
+++ b/Assets/Source/Player/Scripting/Interface/UnityMaterial.cs
@@ -1,0 +1,74 @@
+using UnityEngine;
+
+namespace CreateAR.EnkluPlayer.Scripting
+{
+    /// <summary>
+    /// Unity implementation of IMaterial.
+    /// </summary>
+    public class UnityMaterial : IMaterial
+    {
+        /// <summary>
+        /// Backing material.
+        /// </summary>
+        public Material Material { get; private set; }
+        
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="material"></param>
+        public UnityMaterial(Material material)
+        {
+            Material = material;
+        }
+        
+        /// <inheritdoc />
+        public float GetFloat(string param)
+        {
+            return Material.GetFloat(param);
+        }
+
+        /// <inheritdoc />
+        public void SetFloat(string param, float value)
+        {
+            Material.SetFloat(param, value);
+        }
+
+        /// <inheritdoc />
+        public int GetInt(string param)
+        {
+            return Material.GetInt(param);
+        }
+
+        /// <inheritdoc />
+        public void SetInt(string param, int value)
+        {
+            Material.SetInt(param, value);
+        }
+
+        /// <inheritdoc />
+        public Vec3 GetVec3(string param)
+        {
+            var v4 = Material.GetVector(param);
+            return new Vec3(v4.x, v4.y, v4.z);
+        }
+
+        /// <inheritdoc />
+        public void SetVec3(string param, Vec3 value)
+        {
+            Material.SetVector(param, value.ToVector());
+        }
+
+        /// <inheritdoc />
+        public Col4 GetCol4(string param)
+        {
+            var v4 = Material.GetVector(param);
+            return new Col4(v4.x, v4.y, v4.z, v4.w);
+        }
+
+        /// <inheritdoc />
+        public void SetCol4(string param, Col4 value)
+        {
+            Material.SetVector(param, value.ToColor());
+        }
+    }
+}

--- a/Assets/Source/Player/Scripting/Interface/UnityMaterial.cs.meta
+++ b/Assets/Source/Player/Scripting/Interface/UnityMaterial.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c323e0aeac6948a7b7be414805c09aba
+timeCreated: 1543631233

--- a/Assets/Source/Player/Scripting/Interface/UnityRenderer.cs
+++ b/Assets/Source/Player/Scripting/Interface/UnityRenderer.cs
@@ -1,0 +1,48 @@
+using System;
+using UnityEngine;
+
+namespace CreateAR.EnkluPlayer.Scripting
+{
+    /// <summary>
+    /// A Unity implementation of IRenderer.
+    /// </summary>
+    public class UnityRenderer : IRenderer
+    {
+        /// <summary>
+        /// Backing Unity Renderer.
+        /// </summary>
+        private Renderer _renderer;
+
+        /// <summary>
+        /// Backing Material.
+        /// </summary>
+        private IMaterial _material;
+
+        /// <inheritdoc />
+        public IMaterial SharedMaterial
+        {
+            get { return _material; }
+            set
+            {
+                var unityMat = value as UnityMaterial;
+                if (unityMat == null)
+                {
+                    throw new Exception("Trying to use non UnityMaterial with UnityRenderer");
+                }
+
+                _material = value;
+                _renderer.sharedMaterial = unityMat.Material;
+            }
+        }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="renderer"></param>
+        public UnityRenderer(Renderer renderer)
+        {
+            _renderer = renderer;
+            _material = new UnityMaterial(renderer.sharedMaterial);
+        }
+    }
+}

--- a/Assets/Source/Player/Scripting/Interface/UnityRenderer.cs.meta
+++ b/Assets/Source/Player/Scripting/Interface/UnityRenderer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f232492e6f7d45d4a7ed38fd5ba1415a
+timeCreated: 1543791262


### PR DESCRIPTION
Updates to `AudioJsApi`, `MaterialJsApi`, and `AnimatorJsApi` to support values being backed by schema, so they can be used with the new tweening library.

The three JsApis check for schema first to load default values - otherwise they create schema entries off of the prefab's values. There are a few exceptions, `MaterialJsApi` has some notes for the next Unity upgrade. `AnimatorJsApi` lazily creates schema since only parameter names are known, not type.

All three have tests for loading with/without existing schema entries, and to ensure updating thru the scripting API or schema will reflect on the other. Since handling Materials, AudioSources, and Animators inside of tests is painful without a real material/audio/animator, etc, a lot of this PR ballooned into being just boilerplate for creating interfaces to wrap a lot of the Unity APIs so we can provide test implementations. @thegoldenmule let me know if you have other thoughts for this or don't want the interfaces to be as 1:1 with Unity.