### PR TITLE
Change FloatTween to use Convert.ToSingle() instead of casting to float.

### DIFF
--- a/Assets/Source/Util/Tween/Tween.cs
+++ b/Assets/Source/Util/Tween/Tween.cs
@@ -133,10 +133,10 @@ namespace CreateAR.EnkluPlayer.Util
         /// </summary>
         public FloatTween(ElementSchema schema, TweenData data)
             : base(schema, data)
-        {
+        {    
             _prop = schema.Get<float>(Data.Prop);
-            _originalValue = data.CustomFrom ? (float) data.From : _prop.Value;
-            _diff = (float) data.To - _originalValue;
+            _originalValue = data.CustomFrom ? Convert.ToSingle(data.From) : _prop.Value;
+            _diff = Convert.ToSingle(data.To) - _originalValue;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Ran into an RTE when using `tween.number` in scripting. Jint pushes a double into the object fields for `data.From` and `data.To`, which fails when casting directly to float.