### PR TITLE
Feature/ek 1107 ping aws

### DIFF
--- a/Assets/Resources/ApplicationConfig.json
+++ b/Assets/Resources/ApplicationConfig.json
@@ -18,6 +18,9 @@
                 "BundlesUrl": "https://s3-us-west-2.amazonaws.com:443/axatmtcyltmxltqzltmw.assets.bundles/",
                 "ThumbsUrl": "https://s3-us-west-2.amazonaws.com:443/axatmtcyltmxltqzltmw.assets.thumbs/"
             }
-        ]
+        ],
+        "Ping": {
+            "Enabled": true
+        }
     }
 }

--- a/Assets/Resources/ApplicationConfig.json
+++ b/Assets/Resources/ApplicationConfig.json
@@ -18,9 +18,6 @@
                 "BundlesUrl": "https://s3-us-west-2.amazonaws.com:443/axatmtcyltmxltqzltmw.assets.bundles/",
                 "ThumbsUrl": "https://s3-us-west-2.amazonaws.com:443/axatmtcyltmxltqzltmw.assets.thumbs/"
             }
-        ],
-        "Ping": {
-            "Enabled": true
-        }
+        ]
     }
 }

--- a/Assets/Source/Application/ApplicationConfig.cs
+++ b/Assets/Source/Application/ApplicationConfig.cs
@@ -503,7 +503,7 @@ namespace CreateAR.EnkluPlayer
         /// <summary>
         /// The PingConfig to use.
         /// </summary>
-        public readonly PingConfig Ping = new PingConfig();
+        public PingConfig Ping = new PingConfig();
 
         /// <summary>
         /// Current environment we should connect to.
@@ -756,7 +756,7 @@ namespace CreateAR.EnkluPlayer
         /// <summary>
         /// Whether pings should be sent or not.
         /// </summary>
-        public bool Enabled = false;
+        public bool Enabled = true;
         
         /// <summary>
         /// The interval to send pings, measured in ms.

--- a/Assets/Source/Application/ApplicationConfig.cs
+++ b/Assets/Source/Application/ApplicationConfig.cs
@@ -501,6 +501,11 @@ namespace CreateAR.EnkluPlayer
         public string ApiVersion = "0.0.0";
 
         /// <summary>
+        /// The PingConfig to use.
+        /// </summary>
+        public readonly PingConfig Ping = new PingConfig();
+
+        /// <summary>
         /// Current environment we should connect to.
         /// </summary>
         public string Current;
@@ -624,6 +629,11 @@ namespace CreateAR.EnkluPlayer
                 ApiVersion = overrideConfig.ApiVersion;
             }
 
+            if (overrideConfig.Ping != null)
+            {
+                Ping.SetValues(overrideConfig.Ping);
+            }
+
             Offline = overrideConfig.Offline;
 
             // combine arrays
@@ -735,6 +745,46 @@ namespace CreateAR.EnkluPlayer
         {
             http.Urls.Formatter("trellis").Replacements["userId"] = UserId;
             http.Headers["Authorization"] = string.Format("Bearer {0}", Token);
+        }
+    }
+    
+    /// <summary>
+    /// Configuration for pinging AWS.
+    /// </summary>
+    public class PingConfig
+    {
+        /// <summary>
+        /// Whether pings should be sent or not.
+        /// </summary>
+        public bool Enabled = false;
+        
+        /// <summary>
+        /// The interval to send pings, measured in ms.
+        /// </summary>
+        public int Interval = 30;
+        
+        /// <summary>
+        /// The AWS region to send pings to.
+        /// </summary>
+        public string Region = "us-west-2";
+
+        /// <summary>
+        /// Updates this PingConfig with values from another PingConfig.
+        /// </summary>
+        /// <param name="other"></param>
+        public void SetValues(PingConfig other)
+        {
+            Enabled = other.Enabled;
+            
+            if (other.Interval != 0)
+            {
+                Interval = other.Interval;
+            }
+
+            if (!string.IsNullOrEmpty(other.Region))
+            {
+                Region = other.Region;
+            }
         }
     }
 

--- a/Assets/Source/Application/ApplicationConfig.cs
+++ b/Assets/Source/Application/ApplicationConfig.cs
@@ -631,7 +631,7 @@ namespace CreateAR.EnkluPlayer
 
             if (overrideConfig.Ping != null)
             {
-                Ping.SetValues(overrideConfig.Ping);
+                Ping.Override(overrideConfig.Ping);
             }
 
             Offline = overrideConfig.Offline;
@@ -772,7 +772,7 @@ namespace CreateAR.EnkluPlayer
         /// Updates this PingConfig with values from another PingConfig.
         /// </summary>
         /// <param name="other"></param>
-        public void SetValues(PingConfig other)
+        public void Override(PingConfig other)
         {
             Enabled = other.Enabled;
             

--- a/Assets/Source/Application/Injection/EnkluPlayerModule.cs
+++ b/Assets/Source/Application/Injection/EnkluPlayerModule.cs
@@ -103,6 +103,7 @@ namespace CreateAR.EnkluPlayer
                 }
 
                 binder.Bind<HttpRequestCacher>().To<HttpRequestCacher>().ToSingleton();
+                binder.Bind<NetworkConnectivity>().To<NetworkConnectivity>().ToSingleton();
                 binder.Bind<ApiController>().To<ApiController>().ToSingleton();
 
 #if !UNITY_EDITOR && UNITY_WSA
@@ -685,11 +686,8 @@ namespace CreateAR.EnkluPlayer
                 binder.Bind<IAppDataManager>().ToValue(appData);
                 
                 SystemJsApi.SetDependencies(
-                    config.Network.Ping,
                     binder.GetInstance<IDeviceMetaProvider>(),
-                    binder.GetInstance<IHttpService>(),
-                    binder.GetInstance<IBootstrapper>(),
-                    binder.GetInstance<IMetricsService>());
+                    binder.GetInstance<NetworkConnectivity>());
             }
 
             binder.Bind<IAppController>().To<AppController>().ToSingleton();

--- a/Assets/Source/Application/Injection/EnkluPlayerModule.cs
+++ b/Assets/Source/Application/Injection/EnkluPlayerModule.cs
@@ -685,7 +685,7 @@ namespace CreateAR.EnkluPlayer
                 var appData = binder.GetInstance<IAdminAppDataManager>();
                 binder.Bind<IAppDataManager>().ToValue(appData);
                 
-                SystemJsApi.SetDependencies(
+                SystemJsApi.Initialize(
                     binder.GetInstance<IDeviceMetaProvider>(),
                     binder.GetInstance<NetworkConnectivity>(),
                     binder.GetInstance<IMessageRouter>(),

--- a/Assets/Source/Application/Injection/EnkluPlayerModule.cs
+++ b/Assets/Source/Application/Injection/EnkluPlayerModule.cs
@@ -687,7 +687,10 @@ namespace CreateAR.EnkluPlayer
                 
                 SystemJsApi.SetDependencies(
                     binder.GetInstance<IDeviceMetaProvider>(),
-                    binder.GetInstance<NetworkConnectivity>());
+                    binder.GetInstance<NetworkConnectivity>(),
+                    binder.GetInstance<IMessageRouter>(),
+                    binder.GetInstance<ApiController>(),
+                    binder.GetInstance<ApplicationConfig>());
             }
 
             binder.Bind<IAppController>().To<AppController>().ToSingleton();

--- a/Assets/Source/Application/Injection/EnkluPlayerModule.cs
+++ b/Assets/Source/Application/Injection/EnkluPlayerModule.cs
@@ -656,7 +656,6 @@ namespace CreateAR.EnkluPlayer
                 binder.Bind<IElementJsFactory>().To<ElementJsFactory>().ToSingleton();
                 binder.Bind<IScriptManager>().To<ScriptManager>().ToSingleton();
                 binder.Bind<PlayerJs>().ToValue(LookupComponent<PlayerJs>());
-                SystemJsApi.DeviceMetaProvider = binder.GetInstance<IDeviceMetaProvider>();
 
                 // scripting interfaces
                 {
@@ -684,6 +683,13 @@ namespace CreateAR.EnkluPlayer
 
                 var appData = binder.GetInstance<IAdminAppDataManager>();
                 binder.Bind<IAppDataManager>().ToValue(appData);
+                
+                SystemJsApi.SetDependencies(
+                    config.Network.Ping,
+                    binder.GetInstance<IDeviceMetaProvider>(),
+                    binder.GetInstance<IHttpService>(),
+                    binder.GetInstance<IBootstrapper>(),
+                    binder.GetInstance<IMetricsService>());
             }
 
             binder.Bind<IAppController>().To<AppController>().ToSingleton();

--- a/Assets/Source/Network/NetworkConnectivity.cs
+++ b/Assets/Source/Network/NetworkConnectivity.cs
@@ -1,0 +1,159 @@
+using System.Collections;
+using CreateAR.Commons.Unity.Http;
+using UnityEngine;
+
+namespace CreateAR.EnkluPlayer
+{
+    public class NetworkConnectivity
+    {
+        /// <summary>
+        /// Dependencies.
+        /// </summary>
+        private IHttpService _http;
+        private IBootstrapper _bootstrapper;
+        
+        /// <summary>
+        /// Metric to report ping via.
+        /// </summary>
+        private ValueMetric _pingMetric;
+        
+        /// <summary>
+        /// Backing variables.
+        /// </summary>
+        private float _pingInterval;
+        private string _pingRegion;
+        private bool _enabled;
+        
+        /// <summary>
+        /// ID given to coroutines so if they overlap, they'll nicely die out.
+        /// </summary>
+        private int _coroutineID = 0;
+        
+        /// <summary>
+        /// Whether a ping request is running or not.
+        /// </summary>
+        public bool Enabled
+        {
+            get { return _enabled; }
+            set 
+            {
+                if (_enabled && !value)
+                {
+                    Stop();
+                } 
+                else if (!_enabled && value)
+                {
+                    Start();
+                }
+
+                _enabled = value;
+            }
+        }
+        
+        /// <summary>
+        /// Returns if there's an active connection to the internet.
+        /// </summary>
+        public bool Online { get; private set; }
+        
+        /// <summary>
+        /// Returns the Round Trip Time for the last ping request.
+        /// </summary>
+        public float PingMs { get; private set; }
+        
+        /// <summary>
+        /// AWS region to ping against.
+        /// </summary>
+        public string PingRegion
+        {
+            get { return _pingRegion; }
+            set
+            {
+                Stop();
+                _pingRegion = value;
+                Start();
+            }
+        }
+
+        /// <summary>
+        /// Interval to ping, measured in seconds.
+        /// </summary>
+        public float PingInterval
+        {
+            get { return _pingInterval; }
+            set
+            {
+                Stop();
+                _pingInterval = value;
+                Start();
+            }
+        }
+        
+        public NetworkConnectivity(
+            PingConfig config, 
+            IHttpService http, 
+            IBootstrapper bootstrapper,
+            IMetricsService metrics)
+        {
+            _http = http;
+            _bootstrapper = bootstrapper;
+            _pingMetric = metrics.Value(MetricsKeys.PERF_PING);
+
+            Enabled = config.Enabled;
+        }
+        
+        /// <summary>
+        /// Starts the ping coroutine.
+        /// </summary>
+        public void Start()
+        {
+            _bootstrapper.BootstrapCoroutine(Ping());
+        }
+
+        /// <summary>
+        /// Stops the ping couroutine. Any inflight requests will still finish.
+        /// </summary>
+        public void Stop()
+        {
+            _coroutineID++;
+        }
+
+        /// <summary>
+        /// Pings AWS until stopped.
+        /// </summary>
+        /// <returns></returns>
+        private IEnumerator Ping()
+        {
+            var id = _coroutineID;
+            var url = string.Format("https://ec2.{0}.amazonaws.com/ping", _pingRegion);
+
+            while (id == _coroutineID)
+            {
+                var startTime = Time.realtimeSinceStartup;
+                var inflight = true;
+                
+                // Send the request
+                _http.Get<string>(url).OnSuccess(httpResponse =>
+                {
+                    Online = true;
+                    PingMs = Time.realtimeSinceStartup - startTime;
+                    _pingMetric.Value(PingMs);
+                }).OnFailure(exception =>
+                {
+                    Online = false;
+                }).OnFinally(_ =>
+                {
+                    inflight = false;
+                });
+
+                // Spin for the interval
+                yield return new WaitForSeconds(_pingInterval);
+
+                // Safety, spin if the interval < ping
+                while (inflight)
+                {
+                    yield return null;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Source/Network/NetworkConnectivity.cs
+++ b/Assets/Source/Network/NetworkConnectivity.cs
@@ -5,6 +5,9 @@ using UnityEngine;
 
 namespace CreateAR.EnkluPlayer
 {
+    /// <summary>
+    /// Provides some information about internet access to the app.
+    /// </summary>
     public class NetworkConnectivity
     {
         /// <summary>
@@ -89,6 +92,13 @@ namespace CreateAR.EnkluPlayer
             }
         }
         
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="config"></param>
+        /// <param name="http"></param>
+        /// <param name="bootstrapper"></param>
+        /// <param name="metrics"></param>
         public NetworkConnectivity(
             NetworkConfig config, 
             IHttpService http, 

--- a/Assets/Source/Network/NetworkConnectivity.cs.meta
+++ b/Assets/Source/Network/NetworkConnectivity.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cdb666b2b2514ba7bb8bb14bfdaafb94
+timeCreated: 1544555881

--- a/Assets/Source/Player/Scripting/Interface/App/NetworkJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/App/NetworkJsApi.cs
@@ -1,6 +1,4 @@
-using System.Collections;
-using CreateAR.Commons.Unity.Http;
-using UnityEngine;
+using System;
 
 namespace CreateAR.EnkluPlayer.Scripting
 {
@@ -51,7 +49,8 @@ namespace CreateAR.EnkluPlayer.Scripting
         public float pingInterval
         {
             get { return _networkConnectivity.PingInterval; }
-            set { _networkConnectivity.PingInterval = value; }
+            // Add a slight minimum so scripting can't spam the network too much.
+            set { _networkConnectivity.PingInterval = Math.Max(1, value); }
         }
 
         /// <summary>

--- a/Assets/Source/Player/Scripting/Interface/App/NetworkJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/App/NetworkJsApi.cs
@@ -3,7 +3,7 @@ using System;
 namespace CreateAR.EnkluPlayer.Scripting
 {
     /// <summary>
-    /// 
+    /// Provides information about the network to scripting.
     /// </summary>
     public class NetworkJsApi
     {
@@ -12,6 +12,9 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// </summary>
         private NetworkConnectivity _networkConnectivity;
 
+        /// <summary>
+        /// Whether pings are being sent or not.
+        /// </summary>
         public bool enabled
         {
             get { return _networkConnectivity.Enabled; }
@@ -56,10 +59,6 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// <summary>
         /// Constructor.
         /// </summary>
-        /// <param name="config"></param>
-        /// <param name="http"></param>
-        /// <param name="bootstrapper"></param>
-        /// <param name="metrics"></param>
         public NetworkJsApi(NetworkConnectivity networkConnectivity)
         {
             _networkConnectivity = networkConnectivity;

--- a/Assets/Source/Player/Scripting/Interface/App/NetworkJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/App/NetworkJsApi.cs
@@ -1,0 +1,153 @@
+using System.Collections;
+using CreateAR.Commons.Unity.Http;
+using UnityEngine;
+
+namespace CreateAR.EnkluPlayer.Scripting
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class NetworkJsApi
+    {
+        /// <summary>
+        /// Dependencies.
+        /// </summary>
+        private IHttpService _http;
+        private IBootstrapper _bootstrapper;
+        
+        /// <summary>
+        /// Metric to report ping via.
+        /// </summary>
+        private ValueMetric _pingMetric;
+        
+        /// <summary>
+        /// Backing variables.
+        /// </summary>
+        private float _pingInterval;
+        private string _pingRegion;
+        
+        /// <summary>
+        /// Returns if there's an active connection to the internet.
+        /// </summary>
+        public bool online { get; private set; }
+        
+        /// <summary>
+        /// Returns the Round Trip Time for a ping request.
+        /// </summary>
+        public float pingMs { get; private set; }
+
+        /// <summary>
+        /// AWS region to ping against.
+        /// </summary>
+        public string pingRegion
+        {
+            get { return _pingRegion; }
+            set
+            {
+                Stop();
+                _pingRegion = value;
+                Start();
+            }
+        }
+
+        /// <summary>
+        /// Interval to ping, measured in seconds.
+        /// </summary>
+        public float pingInterval
+        {
+            get { return _pingInterval; }
+            set
+            {
+                Stop();
+                _pingInterval = value;
+                Start();
+            }
+        }
+
+        /// <summary>
+        /// ID given to coroutines so if they overlap, they'll nicely die out.
+        /// </summary>
+        private int _coroutineID = 0;
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="config"></param>
+        /// <param name="http"></param>
+        /// <param name="bootstrapper"></param>
+        /// <param name="metrics"></param>
+        public NetworkJsApi(
+            PingConfig config,
+            IHttpService http, 
+            IBootstrapper bootstrapper,
+            IMetricsService metrics)
+        {
+            _pingInterval = config.Interval;
+            _pingRegion = config.Region;
+            
+            _http = http;
+            _bootstrapper = bootstrapper;
+            _pingMetric = metrics.Value(MetricsKeys.PERF_PING);
+
+            if (config.Enabled)
+            {
+                Start();
+            }
+        }
+
+        /// <summary>
+        /// Starts the ping coroutine.
+        /// </summary>
+        private void Start()
+        {
+            _bootstrapper.BootstrapCoroutine(Ping());
+        }
+
+        /// <summary>
+        /// Stops the ping couroutine. Any inflight requests will still finish.
+        /// </summary>
+        private void Stop()
+        {
+            _coroutineID++;
+        }
+
+        /// <summary>
+        /// Pings AWS until stopped.
+        /// </summary>
+        /// <returns></returns>
+        private IEnumerator Ping()
+        {
+            var id = _coroutineID;
+            var url = string.Format("https://ec2.{0}.amazonaws.com/ping", _pingRegion);
+
+            while (id == _coroutineID)
+            {
+                var startTime = Time.realtimeSinceStartup;
+                var inflight = true;
+                
+                // Send the request
+                _http.Get<string>(url).OnSuccess(httpResponse =>
+                {
+                    online = true;
+                    pingMs = Time.realtimeSinceStartup - startTime;
+                    _pingMetric.Value(pingMs);
+                }).OnFailure(exception =>
+                {
+                    online = false;
+                }).OnFinally(_ =>
+                {
+                    inflight = false;
+                });
+
+                // Spin for the interval
+                yield return new WaitForSeconds(_pingInterval);
+
+                // Safety, spin if the interval < ping
+                while (inflight)
+                {
+                    yield return null;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Source/Player/Scripting/Interface/App/NetworkJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/App/NetworkJsApi.cs
@@ -15,7 +15,7 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// <summary>
         /// Whether pings are being sent or not.
         /// </summary>
-        public bool enabled
+        public bool pingEnabled
         {
             get { return _networkConnectivity.Enabled; }
             set { _networkConnectivity.Enabled = value; }

--- a/Assets/Source/Player/Scripting/Interface/App/NetworkJsApi.cs.meta
+++ b/Assets/Source/Player/Scripting/Interface/App/NetworkJsApi.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cb0a0e7b4cf6493a8afcf33d14df4b3c
+timeCreated: 1544485059

--- a/Assets/Source/Player/Scripting/Interface/App/SystemJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/App/SystemJsApi.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using CreateAR.Commons.Unity.Http;
 using CreateAR.Commons.Unity.Logging;
+using CreateAR.Commons.Unity.Messaging;
+using CreateAR.Trellis.Messages;
 
 namespace CreateAR.EnkluPlayer.Scripting
 {
@@ -21,7 +23,10 @@ namespace CreateAR.EnkluPlayer.Scripting
 
         public static void SetDependencies(
             IDeviceMetaProvider deviceMetaProvider,
-            NetworkConnectivity networkConnectivity)
+            NetworkConnectivity networkConnectivity,
+            IMessageRouter msgRouter,
+            ApiController apiController,
+            ApplicationConfig config)
         {
             if (_configured)
             {
@@ -29,6 +34,7 @@ namespace CreateAR.EnkluPlayer.Scripting
             }
             
             Instance.device = new DeviceJsApi(deviceMetaProvider);
+            Instance.experiences = new ExperienceJsApi(msgRouter, apiController, config);
             Instance.network = new NetworkJsApi(networkConnectivity);
 
             _configured = true;

--- a/Assets/Source/Player/Scripting/Interface/App/SystemJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/App/SystemJsApi.cs
@@ -20,11 +20,8 @@ namespace CreateAR.EnkluPlayer.Scripting
         private static bool _configured;
 
         public static void SetDependencies(
-            PingConfig pingConfig,
             IDeviceMetaProvider deviceMetaProvider,
-            IHttpService httpService,
-            IBootstrapper bootstrapper,
-            IMetricsService metricsService)
+            NetworkConnectivity networkConnectivity)
         {
             if (_configured)
             {
@@ -32,7 +29,7 @@ namespace CreateAR.EnkluPlayer.Scripting
             }
             
             Instance.device = new DeviceJsApi(deviceMetaProvider);
-            Instance.network = new NetworkJsApi(pingConfig, httpService, bootstrapper, metricsService);
+            Instance.network = new NetworkJsApi(networkConnectivity);
 
             _configured = true;
         }

--- a/Assets/Source/Player/Scripting/Interface/App/SystemJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/App/SystemJsApi.cs
@@ -19,16 +19,16 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// <summary>
         /// Guard to make sure this isn't configured twice.
         /// </summary>
-        private static bool _configured;
+        private static bool _initialized;
 
-        public static void SetDependencies(
+        public static void Initialize(
             IDeviceMetaProvider deviceMetaProvider,
             NetworkConnectivity networkConnectivity,
             IMessageRouter msgRouter,
             ApiController apiController,
             ApplicationConfig config)
         {
-            if (_configured)
+            if (_initialized)
             {
                 throw new Exception("Dependencies already set!");
             }
@@ -37,7 +37,7 @@ namespace CreateAR.EnkluPlayer.Scripting
             Instance.experiences = new ExperienceJsApi(msgRouter, apiController, config);
             Instance.network = new NetworkJsApi(networkConnectivity);
 
-            _configured = true;
+            _initialized = true;
         }
 
         /// <summary>

--- a/Assets/Source/Util/Analytics/MetricsKeys.cs
+++ b/Assets/Source/Util/Analytics/MetricsKeys.cs
@@ -69,5 +69,6 @@
         ///////////////////////////////////////////////////////////////////////
         public const string PERF_FRAMETIME = "Perf.FrameTime";
         public const string PERF_MEMORY = "Perf.Memory";
+        public const string PERF_PING = "Perf.Ping";
     }
 }


### PR DESCRIPTION
- Added a new `NetworkConnectivity` class to measure ping and overall internet access
- Added a new `NetworkJsApi` to expose ping & internet access to the scripting interface.
- Added PingConfig to NetworkConfig.
- Changed SystemJsApi dependencies to be passed through a single `SetDependencies` call.

Right now, pinging can be started with some override config:
```
"Ping": {
    "Enabled": true,
    "Interval": 5
}
```
...or via scripting:
```
system.network.pingEnabled = true;
```
The interval & region can also be configured via scripting. Scripting also has access to a bool for `system.network.online`. 

The method of calculating ping isn't the best, since it includes not just raw RTT time but some overhead of callbacks, etc. Should be good enough for now though.