### PR TITLE
Feature/ek 1111 snapjs upgrade

### DIFF
--- a/Assets/Source/Player/Scripting/Interop/SnapJsInterface.cs
+++ b/Assets/Source/Player/Scripting/Interop/SnapJsInterface.cs
@@ -1,7 +1,10 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
+using CreateAR.Commons.Unity.Async;
 using CreateAR.Commons.Unity.Logging;
 using CreateAR.Trellis.Messages;
 using CreateAR.Trellis.Messages.TriggerSnap;
+using Jint;
 using Jint.Native;
 using JsFunc = System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue>;
 
@@ -37,9 +40,9 @@ namespace CreateAR.EnkluPlayer
         /// <summary>
         /// Triggers a snap to be taken.
         /// </summary>
-        public void trigger(string tag)
+        public void trigger(Engine engine, string tag)
         {
-            trigger(tag, null);
+            trigger_callback(engine, tag, null);
         }
 
         /// <summary>
@@ -47,51 +50,85 @@ namespace CreateAR.EnkluPlayer
         /// </summary>
         /// <param name="tag"></param>
         /// <param name="callback"></param>
-        public void trigger(string tag, JsFunc callback)
+        public void trigger_callback(Engine engine, string tag, JsFunc callback)
         {
             Log.Info(this, "Trigger a snap.");
-
+            
             _preferences
                 .ForCurrentUser()
                 .OnSuccess(prefs =>
                 {
+                    var getOrgToken = new AsyncToken<string>();
+                    
                     // pick first organization
                     var org = prefs.Data.DeviceRegistrations.FirstOrDefault();
-                    if (null == org)
+
+                    if (null != org)
                     {
-                        Log.Warning(this, "No organizations.");
-                        return;
+                        getOrgToken.Succeed(org.OrgId);
                     }
+                    else
+                    {
+                        // Attempt to get the org if it wasn't available?!
+                        Log.Warning(this, "No organizations.");
 
-                    Log.Info(this, "Making snap request.");
-
-                    _api
-                        .Snaps
-                        .TriggerSnap(org.OrgId, tag, new Request())
-                        .OnSuccess(response =>
+                        _api.Organizations.GetMyOrganizations().OnSuccess(response =>
                         {
-                            if (response.Payload.Success)
+                            if (response.Payload.Success && response.Payload.Body.Length > 0)
                             {
-                                Log.Info(this, "Trigger succeeded.");
-                                InvokeCallback(callback, true);
+                                getOrgToken.Succeed(response.Payload.Body[0].Id);
                             }
                             else
                             {
-                                Log.Warning(this,
-                                    "Trigger could not be sent : {0}",
-                                    response.Payload.Error);
-                                InvokeCallback(callback, false, response.Payload.Error);
+                                getOrgToken.Fail(new Exception("GetMyOrganizations success: false"));
                             }
-                        })
-                        .OnFailure(exception =>
+                        }).OnFailure(exception =>
                         {
-                            Log.Warning(this,
-                                "Trigger could not be fired : {0}",
-                                exception);
-                            InvokeCallback(callback, false, exception.ToString());
+                            getOrgToken.Fail(exception);
                         });
+                    }
+                    
+                    // After org is known
+                    getOrgToken.OnSuccess(orgId =>
+                    {
+                        Log.Info(this, "Making snap request.");
+
+                        _api
+                            .Snaps
+                            .TriggerSnap(orgId, tag, new Request())
+                            .OnSuccess(response =>
+                            {
+                                if (response.Payload.Success)
+                                {
+                                    Log.Info(this, "Trigger succeeded.");
+                                    InvokeCallback(engine, callback, true);
+                                }
+                                else
+                                {
+                                    Log.Warning(this,
+                                        "Trigger could not be sent : {0}",
+                                        response.Payload.Error);
+                                    InvokeCallback(engine, callback, false, response.Payload.Error);
+                                }
+                            })
+                            .OnFailure(exception =>
+                            {
+                                Log.Warning(this,
+                                    "Trigger could not be fired : {0}",
+                                    exception);
+                                InvokeCallback(engine, callback, false, exception.ToString());
+                            });
+                    }).OnFailure(exception =>
+                    {
+                        InvokeCallback(engine, callback, false, exception.ToString());
+                    });
+                    
                 })
-                .OnFailure(ex => Log.Error(this, "Could not get user preferences : {0}", ex));
+                .OnFailure(ex =>
+                {
+                    Log.Error(this, "Could not get user preferences : {0}", ex);
+                    InvokeCallback(engine, callback, false, ex.ToString());
+                });
         }
 
         /// <summary>
@@ -100,11 +137,11 @@ namespace CreateAR.EnkluPlayer
         /// <param name="callback"></param>
         /// <param name="success"></param>
         /// <param name="msg"></param>
-        private void InvokeCallback(JsFunc callback, bool success, string msg = "")
+        private void InvokeCallback(Engine engine, JsFunc callback, bool success, string msg = "")
         {
             if (callback != null)
             {
-                callback(null, new[] { new JsValue(success), new JsValue(msg) });
+                callback(JsValue.FromObject(engine, this), new[] { new JsValue(success), new JsValue(msg) });
             }
         }
     }

--- a/Assets/Source/Player/Scripting/Interop/SnapJsInterface.cs
+++ b/Assets/Source/Player/Scripting/Interop/SnapJsInterface.cs
@@ -2,6 +2,8 @@
 using CreateAR.Commons.Unity.Logging;
 using CreateAR.Trellis.Messages;
 using CreateAR.Trellis.Messages.TriggerSnap;
+using Jint.Native;
+using JsFunc = System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue>;
 
 namespace CreateAR.EnkluPlayer
 {
@@ -37,6 +39,16 @@ namespace CreateAR.EnkluPlayer
         /// </summary>
         public void trigger(string tag)
         {
+            trigger(tag, null);
+        }
+
+        /// <summary>
+        /// Triggers a snap to be taken. Notifies the callback on success/failure.
+        /// </summary>
+        /// <param name="tag"></param>
+        /// <param name="callback"></param>
+        public void trigger(string tag, JsFunc callback)
+        {
             Log.Info(this, "Trigger a snap.");
 
             _preferences
@@ -61,19 +73,39 @@ namespace CreateAR.EnkluPlayer
                             if (response.Payload.Success)
                             {
                                 Log.Info(this, "Trigger succeeded.");
+                                InvokeCallback(callback, true);
                             }
                             else
                             {
                                 Log.Warning(this,
                                     "Trigger could not be sent : {0}",
                                     response.Payload.Error);
+                                InvokeCallback(callback, false, response.Payload.Error);
                             }
                         })
-                        .OnFailure(exception => Log.Warning(this,
-                            "Trigger could not be fired : {0}",
-                            exception));
+                        .OnFailure(exception =>
+                        {
+                            Log.Warning(this,
+                                "Trigger could not be fired : {0}",
+                                exception);
+                            InvokeCallback(callback, false, exception.ToString());
+                        });
                 })
                 .OnFailure(ex => Log.Error(this, "Could not get user preferences : {0}", ex));
+        }
+
+        /// <summary>
+        /// Invokes a JsFunc with the specified parameters.
+        /// </summary>
+        /// <param name="callback"></param>
+        /// <param name="success"></param>
+        /// <param name="msg"></param>
+        private void InvokeCallback(JsFunc callback, bool success, string msg = "")
+        {
+            if (callback != null)
+            {
+                callback(null, new[] { new JsValue(success), new JsValue(msg) });
+            }
         }
     }
 }


### PR DESCRIPTION
- Added a callback to snap triggering so success and an error message are available to scripting.
- Snap triggers attempt to get the user's orgId if there wasn't one registered.

Ran into a bug with jint while trying to do this, so the new callback support is under `trigger_callback` for now. The issue was that overloading functions worked fine until I had to add `Engine` as the first parameter. Overloading while trying to inject `Engine` has jint throwing a "No public methods with the specified arguments" warning.