### PR TITLE
Feature/metrics

### DIFF
--- a/Assets/Source/Application/ApplicationConfig.cs
+++ b/Assets/Source/Application/ApplicationConfig.cs
@@ -834,6 +834,11 @@ namespace CreateAR.EnkluPlayer
         public string ApplicationKey;
 
         /// <summary>
+        /// Metrics data configuration.
+        /// </summary>
+        public MetricsDataConfig MetricsDataConfig = new MetricsDataConfig();
+
+        /// <summary>
         /// Overrides settings.
         /// </summary>
         /// <param name="config">The config.</param>
@@ -855,6 +860,54 @@ namespace CreateAR.EnkluPlayer
             {
                 Targets = config.Targets;
             }
+
+            if (config.MetricsDataConfig != null)
+            {
+                MetricsDataConfig.Override(config.MetricsDataConfig);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Configuratino for various metrics datapoints
+    /// </summary>
+    public class MetricsDataConfig
+    {
+        /// <summary>
+        /// Whether datapoints should be uploaded or not.
+        /// </summary>
+        public bool Enabled = true;
+        
+        /// <summary>
+        /// The interval when datapoints will update.
+        /// </summary>
+        public int Interval = 30;
+        
+        /// <summary>
+        /// Battery level tracked.
+        /// </summary>
+        public bool Battery = true;
+
+        /// <summary>
+        /// Session duration tracked.
+        /// </summary>
+        public bool SessionDuration = true;
+
+        /// <summary>
+        /// Overrides the configuration.
+        /// </summary>
+        /// <param name="other"></param>
+        public void Override(MetricsDataConfig other)
+        {
+            Enabled = other.Enabled;
+
+            if (other.Interval > 0)
+            {
+                Interval = other.Interval;
+            }
+
+            Battery = other.Battery;
+            SessionDuration = other.SessionDuration;
         }
     }
 

--- a/Assets/Source/Application/Injection/EnkluPlayerModule.cs
+++ b/Assets/Source/Application/Injection/EnkluPlayerModule.cs
@@ -208,6 +208,7 @@ namespace CreateAR.EnkluPlayer
                     binder.Bind<ElementActionHelperService>().To<ElementActionHelperService>().ToSingleton();
                     binder.Bind<UserPreferenceService>().To<UserPreferenceService>().ToSingleton();
                     binder.Bind<VersioningService>().To<VersioningService>().ToSingleton();
+                    binder.Bind<MetricsUpdateService>().To<MetricsUpdateService>().ToSingleton();
 
 #if NETFX_CORE
                     binder.Bind<CommandService>().To<UwpCommandService>().ToSingleton();
@@ -389,7 +390,8 @@ namespace CreateAR.EnkluPlayer
                         binder.GetInstance<UserPreferenceService>(),
                         binder.GetInstance<DeviceResourceUpdateService>(),
                         binder.GetInstance<ApplicationStateService>(),
-                        binder.GetInstance<CommandService>()
+                        binder.GetInstance<CommandService>(),
+                        binder.GetInstance<MetricsUpdateService>()
                     }));
                 binder.Bind<Application>().To<Application>().ToSingleton();
             }

--- a/Assets/Source/Application/Services/MetricsUpdateService.cs
+++ b/Assets/Source/Application/Services/MetricsUpdateService.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections;
+using CreateAR.Commons.Unity.Http;
+using CreateAR.Commons.Unity.Messaging;
+using UnityEngine;
+
+namespace CreateAR.EnkluPlayer
+{
+    /// <summary>
+    /// Service that sends specific metric datapoints.
+    /// </summary>
+    public class MetricsUpdateService : ApplicationService
+    {
+        /// <summary>
+        /// Configuration to use.
+        /// </summary>
+        private MetricsDataConfig _config;
+
+        /// <summary>
+        /// Dependencies.
+        /// </summary>
+        private readonly IMessageRouter _messages;
+        private readonly IBootstrapper _bootstrapper;
+        private readonly IDeviceMetaProvider _deviceMeta;
+
+        /// <summary>
+        /// Metrics.
+        /// </summary>
+        private readonly ValueMetric _batteryMetric;
+        private readonly ValueMetric _sessionMetric;
+
+        /// <summary>
+        /// Last time that an experience was started.
+        /// </summary>
+        private float _lastPlayTime;
+
+        /// <summary>
+        /// Cached unsub function.
+        /// </summary>
+        private Action _playUnsub;
+
+        /// <summary>
+        /// Current coroutine runner. Guards against rapid service Stop/Start.
+        /// </summary>
+        private int _currentId;
+        
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public MetricsUpdateService(
+            MessageTypeBinder binder,
+            IMessageRouter messages,
+            ApplicationConfig config,
+            IMetricsService metrics,
+            IBootstrapper bootstrapper,
+            IDeviceMetaProvider deviceMeta) : base(binder, messages)
+        {
+            _messages = messages;
+            _bootstrapper = bootstrapper;
+            _config = config.Metrics.MetricsDataConfig;
+            _deviceMeta = deviceMeta;
+
+            _batteryMetric = metrics.Value(MetricsKeys.PERF_BATTERY);
+            _sessionMetric = metrics.Value(MetricsKeys.PERF_SESSION);
+        }
+
+        /// <inheritdoc />
+        public override void Start()
+        {
+            base.Start();
+
+            if (_config.Enabled)
+            {
+                _bootstrapper.BootstrapCoroutine(UpdateData());
+            }
+
+            _playUnsub = _messages.Subscribe(MessageTypes.PLAY, UpdateSessionStart);
+        }
+
+        /// <inheritdoc />
+        public override void Stop()
+        {
+            base.Stop();
+
+            _playUnsub();
+            _currentId++;
+        }
+
+        /// <summary>
+        /// Updates the enabled metrics datapoints per the configuration's interval.
+        /// </summary>
+        /// <returns></returns>
+        private IEnumerator UpdateData()
+        {
+            var id = _currentId;
+            
+            while (id == _currentId)
+            {
+                yield return new WaitForSeconds(_config.Interval);
+
+                if (_config.Battery)
+                {
+                    var meta = _deviceMeta.Meta();
+
+                    _batteryMetric.Value(meta.Battery * 100);    // Send as 0->100
+                }
+
+                if (_config.SessionDuration)
+                {
+                    _sessionMetric.Value((Time.realtimeSinceStartup - _lastPlayTime) / 60); // Send as minutes
+                }
+                
+                // TODO: Add temperature reporting
+            }
+        }
+
+        /// <summary>
+        /// Resets the cached experience start time.
+        /// </summary>
+        /// <param name="payload"></param>
+        private void UpdateSessionStart(object payload)
+        {
+            _lastPlayTime = Time.realtimeSinceStartup;
+        }
+    }
+}

--- a/Assets/Source/Application/Services/MetricsUpdateService.cs.meta
+++ b/Assets/Source/Application/Services/MetricsUpdateService.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f976cc15631c4d309fe122684efca3ba
+timeCreated: 1544572270

--- a/Assets/Source/Application/States/Play/Hmd/PrimaryAnchorManager.cs
+++ b/Assets/Source/Application/States/Play/Hmd/PrimaryAnchorManager.cs
@@ -471,16 +471,6 @@ namespace CreateAR.EnkluPlayer
                 {
                     Messages_OnAutoExport(anchor);
                 }
-
-                // Ensure we're only subbing once
-                Anchor.OnLocated -= Anchor_OnLocatedChanged;
-                Anchor.OnUnlocated -= Anchor_OnLocatedChanged;
-                
-                Anchor.OnLocated += Anchor_OnLocatedChanged;
-                Anchor.OnUnlocated += Anchor_OnLocatedChanged;
-                
-                // Proc the event to push the current state
-                Anchor_OnLocatedChanged(Anchor);
             }
 
             if (null != Anchor)
@@ -1005,25 +995,6 @@ Errors: {3} / {0}",
             _txns
                 .Request(new ElementTxn(_sceneId).Update(_scan.Id, "srcUrl", url))
                 .OnFailure(ex => Log.Error(this, "Could not set url of scan element : {0}", ex));
-        }
-
-        /// <summary>
-        /// Called when an Anchor has either located or unlocated.
-        /// </summary>
-        /// <param name="anchor"></param>
-        private void Anchor_OnLocatedChanged(WorldAnchorWidget anchor)
-        {
-            var status = anchor.Status;
-            var name = anchor.Schema.Get<string>("name").Value;
-            switch (status)
-            {
-                case WorldAnchorWidget.WorldAnchorStatus.IsReadyLocated:
-                    _metrics.Value(MetricsKeys.ANCHOR_STATE_UNLOCATED_NAMED(name)).Value(1);
-                    break;
-                case WorldAnchorWidget.WorldAnchorStatus.IsReadyNotLocated:
-                    _metrics.Value(MetricsKeys.ANCHOR_STATE_UNLOCATED_NAMED(name)).Value(0);
-                    break;
-            }
         }
     }
 }

--- a/Assets/Source/Application/States/Play/Hmd/PrimaryAnchorManager.cs
+++ b/Assets/Source/Application/States/Play/Hmd/PrimaryAnchorManager.cs
@@ -471,6 +471,16 @@ namespace CreateAR.EnkluPlayer
                 {
                     Messages_OnAutoExport(anchor);
                 }
+
+                // Ensure we're only subbing once
+                Anchor.OnLocated -= Anchor_OnLocatedChanged;
+                Anchor.OnUnlocated -= Anchor_OnLocatedChanged;
+                
+                Anchor.OnLocated += Anchor_OnLocatedChanged;
+                Anchor.OnUnlocated += Anchor_OnLocatedChanged;
+                
+                // Proc the event to push the current state
+                Anchor_OnLocatedChanged(Anchor);
             }
 
             if (null != Anchor)
@@ -995,6 +1005,25 @@ Errors: {3} / {0}",
             _txns
                 .Request(new ElementTxn(_sceneId).Update(_scan.Id, "srcUrl", url))
                 .OnFailure(ex => Log.Error(this, "Could not set url of scan element : {0}", ex));
+        }
+
+        /// <summary>
+        /// Called when an Anchor has either located or unlocated.
+        /// </summary>
+        /// <param name="anchor"></param>
+        private void Anchor_OnLocatedChanged(WorldAnchorWidget anchor)
+        {
+            var status = anchor.Status;
+            var name = anchor.Schema.Get<string>("name").Value;
+            switch (status)
+            {
+                case WorldAnchorWidget.WorldAnchorStatus.IsReadyLocated:
+                    _metrics.Value(MetricsKeys.ANCHOR_STATE_UNLOCATED_NAMED(name)).Value(1);
+                    break;
+                case WorldAnchorWidget.WorldAnchorStatus.IsReadyNotLocated:
+                    _metrics.Value(MetricsKeys.ANCHOR_STATE_UNLOCATED_NAMED(name)).Value(0);
+                    break;
+            }
         }
     }
 }

--- a/Assets/Source/Application/States/Play/PlayApplicationState.cs
+++ b/Assets/Source/Application/States/Play/PlayApplicationState.cs
@@ -83,6 +83,11 @@ namespace CreateAR.EnkluPlayer
         private int _trackingId;
 
         /// <summary>
+        /// Whether the AR service has reported tracking loss or not.
+        /// </summary>
+        private bool _trackingLost;
+
+        /// <summary>
         /// Plays an App.
         /// </summary>
         public PlayApplicationState(
@@ -349,6 +354,13 @@ namespace CreateAR.EnkluPlayer
         /// </summary>
         private void Ar_OnTrackingOffline()
         {
+            // Guard against AR service reporting different, but still failing, states
+            if (_trackingLost)
+            {
+                return;
+            }
+            _trackingLost = true;
+            
             Log.Info(this, "Ar tracking lost!");
 
             _trackingId = _metrics.Timer(MetricsKeys.ANCHOR_TRACKING_LOST).Start();
@@ -364,6 +376,8 @@ namespace CreateAR.EnkluPlayer
         /// </summary>
         private void Ar_OnTrackingOnline()
         {
+            _trackingLost = false;
+            
             Log.Info(this, "Ar tracking back online.");
 
             _metrics.Timer(MetricsKeys.ANCHOR_TRACKING_LOST).Stop(_trackingId);

--- a/Assets/Source/Util/Analytics/MetricsKeys.cs
+++ b/Assets/Source/Util/Analytics/MetricsKeys.cs
@@ -48,6 +48,11 @@
         public const string ANCHOR_STATE_UNLOCATEDRATIO = "WorldAnchor.State.UnlocatedRatio";
         public const string ANCHOR_STATE_LOCATEDRATIO = "WorldAnchor.State.LocatedRatio";
 
+        public static string ANCHOR_STATE_UNLOCATED_NAMED(string name)
+        {
+            return "WorldAnchor.State.Unlocated." + name.Replace(" ", "-");
+        }
+
         ///////////////////////////////////////////////////////////////////////
         /// Scripts
         ///////////////////////////////////////////////////////////////////////

--- a/Assets/Source/Util/Analytics/MetricsKeys.cs
+++ b/Assets/Source/Util/Analytics/MetricsKeys.cs
@@ -70,5 +70,7 @@
         public const string PERF_FRAMETIME = "Perf.FrameTime";
         public const string PERF_MEMORY = "Perf.Memory";
         public const string PERF_PING = "Perf.Ping";
+        public const string PERF_BATTERY = "Perf.Battery";
+        public const string PERF_SESSION = "Perf.Session";
     }
 }

--- a/Assets/Source/Util/Analytics/MetricsKeys.cs
+++ b/Assets/Source/Util/Analytics/MetricsKeys.cs
@@ -48,11 +48,6 @@
         public const string ANCHOR_STATE_UNLOCATEDRATIO = "WorldAnchor.State.UnlocatedRatio";
         public const string ANCHOR_STATE_LOCATEDRATIO = "WorldAnchor.State.LocatedRatio";
 
-        public static string ANCHOR_STATE_UNLOCATED_NAMED(string name)
-        {
-            return "WorldAnchor.State.Unlocated." + name.Replace(" ", "-");
-        }
-
         ///////////////////////////////////////////////////////////////////////
         /// Scripts
         ///////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
**MetricsUpdateService**
Created a service to track specific metric datapoints that are useful for performance / experience analysis. Currently it is responsible for pushing battery & session duration values.

**PrimaryAnchorManager**
Now sends a metric when individual anchors are specifically unlocated. Importing/Loading/Ready all report 0. 1 is sent when an anchor is unlocated. These metrics could be useful to determine if a specific anchor is consistently unlocated. I added a static function to `MetricsKeys` to handle formatting an anchor's name into a safe metric key. That could be done in the anchor manager itself. Curious what your thoughts are on that one @thegoldenmule.

**PlayApplicationState**
Added a guard to make sure the timer used isn't overwritten. According to the Unity docs, there are multiple states of unlocatedness, so the guard ensures if the device is flip/flopping between different unlocated states that we're not losing tracking time by replacing the timer.