### PR TITLE
AppDataLoader timeout

### DIFF
--- a/Assets/Source/Application/ApplicationConfig.cs
+++ b/Assets/Source/Application/ApplicationConfig.cs
@@ -506,6 +506,11 @@ namespace CreateAR.EnkluPlayer
         public PingConfig Ping = new PingConfig();
 
         /// <summary>
+        /// How long to wait before loading from disk. 0 - Off.
+        /// </summary>
+        public float DiskFallbackTime = 0;
+
+        /// <summary>
         /// Current environment we should connect to.
         /// </summary>
         public string Current;
@@ -632,6 +637,11 @@ namespace CreateAR.EnkluPlayer
             if (overrideConfig.Ping != null)
             {
                 Ping.Override(overrideConfig.Ping);
+            }
+
+            if (overrideConfig.DiskFallbackTime > 0)
+            {
+                DiskFallbackTime = overrideConfig.DiskFallbackTime;
             }
 
             Offline = overrideConfig.Offline;

--- a/Assets/Source/Application/ApplicationConfig.cs
+++ b/Assets/Source/Application/ApplicationConfig.cs
@@ -508,7 +508,7 @@ namespace CreateAR.EnkluPlayer
         /// <summary>
         /// How long to wait before loading from disk. 0 - Off.
         /// </summary>
-        public float DiskFallbackTime = 0;
+        public float DiskFallbackSecs = 0;
 
         /// <summary>
         /// Current environment we should connect to.
@@ -639,9 +639,9 @@ namespace CreateAR.EnkluPlayer
                 Ping.Override(overrideConfig.Ping);
             }
 
-            if (overrideConfig.DiskFallbackTime > 0)
+            if (overrideConfig.DiskFallbackSecs > float.Epsilon)
             {
-                DiskFallbackTime = overrideConfig.DiskFallbackTime;
+                DiskFallbackSecs = overrideConfig.DiskFallbackSecs;
             }
 
             Offline = overrideConfig.Offline;

--- a/Assets/Source/Application/States/Play/App/AppDataLoader.cs
+++ b/Assets/Source/Application/States/Play/App/AppDataLoader.cs
@@ -304,8 +304,6 @@ namespace CreateAR.EnkluPlayer
                     () => _api.PublishedApps.GetPublishedApp(appId))
                 .OnSuccess(response =>
                 {
-                    Log.Warning(this, "response!");
-                    
                     Log.Info(this, "Retrieved scene list:");
                     for (var i = 0; i < response.Body.Scenes.Length; i++)
                     {
@@ -349,8 +347,6 @@ namespace CreateAR.EnkluPlayer
                     () => _api.PublishedApps.GetPublishedAssets(appId))
                 .OnSuccess(response =>
                 {
-                    Log.Warning(this, "response!");
-                    
                     var assets = response.Body.Assets.Select(ToAssetData).ToArray();
                     var @event = new AssetListEvent
                     {
@@ -384,8 +380,6 @@ namespace CreateAR.EnkluPlayer
                     () => _api.PublishedApps.GetPublishedAppScripts(appId))
                 .OnSuccess(response =>
                 {
-                    Log.Warning(this, "response!");
-                    
                     var scripts = response.Body.Select(ToScriptData).ToArray();
                     var @event = new ScriptListEvent
                     {

--- a/Assets/Source/Application/States/Play/App/AppDataLoader.cs
+++ b/Assets/Source/Application/States/Play/App/AppDataLoader.cs
@@ -228,7 +228,7 @@ namespace CreateAR.EnkluPlayer
 
             // Setup primary behavior downloads
             _primaryLoadToken = Async.All(
-                    LoadPrerequisites(appId, HttpRequestCacher.LoadBehavior.DiskOnly), 
+                    LoadPrerequisites(appId, behavior), 
                     LoadScenes(appId, behavior))
                 .OnSuccess(_ => rtnToken.Succeed(Void.Instance))
                 .OnFailure(rtnToken.Fail)

--- a/Assets/Source/Application/States/Play/App/AppDataLoader.cs
+++ b/Assets/Source/Application/States/Play/App/AppDataLoader.cs
@@ -228,8 +228,7 @@ namespace CreateAR.EnkluPlayer
 
             // Setup primary behavior downloads
             _primaryLoadToken = Async.All(
-                    GetAssets(appId, behavior), 
-                    GetScripts(appId, behavior), 
+                    LoadPrerequisites(appId, HttpRequestCacher.LoadBehavior.DiskOnly), 
                     LoadScenes(appId, behavior))
                 .OnSuccess(_ => rtnToken.Succeed(Void.Instance))
                 .OnFailure(rtnToken.Fail)
@@ -268,8 +267,7 @@ namespace CreateAR.EnkluPlayer
             Log.Warning(this, "Timeout waiting for network content. Loading from disk.");
 
             Async.All(
-                    GetAssets(appId, HttpRequestCacher.LoadBehavior.DiskOnly),
-                    GetScripts(appId, HttpRequestCacher.LoadBehavior.DiskOnly),
+                    LoadPrerequisites(appId, HttpRequestCacher.LoadBehavior.DiskOnly),
                     LoadScenes(appId, HttpRequestCacher.LoadBehavior.DiskOnly))
                 .OnSuccess(_ => { rtnToken.Succeed(Void.Instance); })
                 .OnFailure(rtnToken.Fail)
@@ -285,6 +283,15 @@ namespace CreateAR.EnkluPlayer
             _assetToken = null;
             _scriptToken = null;
             _sceneToken = null;
+        }
+
+        private IAsyncToken<Void> LoadPrerequisites(string appId, HttpRequestCacher.LoadBehavior behavior)
+        {
+            return Async.Map(
+                Async.All(
+                    GetAssets(appId, behavior),
+                    GetScripts(appId, behavior)),
+                _ => Void.Instance);
         }
 
         /// <summary>

--- a/Assets/Source/Application/States/Play/App/AppDataLoader.cs
+++ b/Assets/Source/Application/States/Play/App/AppDataLoader.cs
@@ -285,6 +285,9 @@ namespace CreateAR.EnkluPlayer
             _sceneToken = null;
         }
 
+        /// <summary>
+        /// Loads prerequisites for an app.
+        /// </summary>
         private IAsyncToken<Void> LoadPrerequisites(string appId, HttpRequestCacher.LoadBehavior behavior)
         {
             return Async.Map(

--- a/Assets/Source/Application/States/Play/App/AppDataLoader.cs
+++ b/Assets/Source/Application/States/Play/App/AppDataLoader.cs
@@ -266,9 +266,9 @@ namespace CreateAR.EnkluPlayer
             });
 
             // Set delay before giving up on the network load
-            if (_networkConfig.DiskFallbackTime > 0 && behavior == HttpRequestCacher.LoadBehavior.NetworkFirst)
+            if (_networkConfig.DiskFallbackSecs > float.Epsilon && behavior == HttpRequestCacher.LoadBehavior.NetworkFirst)
             {
-                _bootstrapper.BootstrapCoroutine(WaitForLoad(_networkConfig.DiskFallbackTime, appId, rtnToken));
+                _bootstrapper.BootstrapCoroutine(WaitForLoad(_networkConfig.DiskFallbackSecs, appId, rtnToken));
             }
             
             return rtnToken;


### PR DESCRIPTION
Targeting 0.14.0, not sure if you wanted to sneak this in before pushing the build out or not.

NetworkConfig:
- Added "DiskFallbackTime". When nonzero, AppDataLoader will use this delay before ignoring network loading.

AppDataLoader:
- Added a delay that starts when network loading begins. If all of the network data hasn't finished, the loader falls back to loading from disk and ignores any late responses from the original network load attempts.

This isn't perfect - there's a chance that 1/3 or 2/3 of the network requests will finish before the delay trips. The successful network loads shouldn't be used, since they might contain IDs that the remaining data from disk doesn't know about, or vice verse. The disk fallback will load all 3 requests from disk again, and resend the various `RECV_X_LIST` messages, but it'd probably be better if the network requests didn't send a message in that case.

As far as testing goes, the normal loading works still. I got a variety of test scenarios on a saturated network (thank you GTA5 for being a giant blob to download over time). Both cases of no network data coming in, or partial network data coming in first, resulted in successful loads and everything seemed okay.