### PR TITLE
EK-1159: Don't notify client of events that originated in the client.

### DIFF
--- a/Assets/Source/Application/States/Play/Desktop/DesktopDesignController.cs
+++ b/Assets/Source/Application/States/Play/Desktop/DesktopDesignController.cs
@@ -374,6 +374,9 @@ namespace CreateAR.EnkluPlayer
         {
             // send to the OTHER SIDE
             var selectedObjs = args.ObjectsWhichWereSelected;
+            var notifyClient = args.SelectReason != ObjectSelectReason.SetSelectedCall &&
+                               args.DeselectReason != ObjectDeselectReason.ClearSelectionCall;
+
             if (selectedObjs.Count == 1)
             {
                 var selected = selectedObjs[0].GetComponent<ElementUpdateMonobehaviour>();
@@ -383,17 +386,23 @@ namespace CreateAR.EnkluPlayer
                     return;
                 }
 
-                _bridge.Send(string.Format(
-                    @"{{""type"":{0}, ""sceneId"":""{1}"", ""elementId"":""{2}""}}",
-                    MessageTypes.BRIDGE_HELPER_SELECT,
-                    _scenes.All[0],
-                    selected.Element.Id));
+                if (notifyClient)
+                {
+                    _bridge.Send(string.Format(
+                        @"{{""type"":{0}, ""sceneId"":""{1}"", ""elementId"":""{2}""}}",
+                        MessageTypes.BRIDGE_HELPER_SELECT,
+                        _scenes.All[0],
+                        selected.Element.Id));                    
+                }
             }
             else if (0 == selectedObjs.Count)
             {
-                _bridge.Send(string.Format(
-                    @"{{""type"":{0}}}",
-                    MessageTypes.BRIDGE_HELPER_SELECT));
+                if (notifyClient)
+                {
+                    _bridge.Send(string.Format(
+                        @"{{""type"":{0}}}",
+                        MessageTypes.BRIDGE_HELPER_SELECT));                    
+                }
             }
         }
 

--- a/Assets/ThirdParty/Runtime Level Design/Scripts/Selection/RTObjectSelection.cs
+++ b/Assets/ThirdParty/Runtime Level Design/Scripts/Selection/RTObjectSelection.cs
@@ -383,7 +383,7 @@ namespace RLD
 
             // We will need these later to fire a selection changed event
             bool selectionWasChanged = false;
-            ObjectSelectReason selectReason = ObjectSelectReason.None;
+            ObjectSelectReason selectReason = ObjectSelectReason.SetSelectedCall;
             ObjectDeselectReason deselectReason = ObjectDeselectReason.None;
             List<GameObject> objectsWhichWereSelected = new List<GameObject>();
             List<GameObject> objectsWhichWereDeselected = new List<GameObject>();


### PR DESCRIPTION
[EK-1159](https://enkluplay.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=EK&modal=detail&selectedIssue=EK-1159)

`RTObjectSelection.ClearSelection` and `RTObjectSelection.SetSelectedObjects` are both only used by the `IDesignController`. If they are intended for more general use, we can pass in a reason instead of setting one inside these two.

Another possible improvement would be using a source AND a reason.

If I misinterpreted intent, please let me know.