### PR TITLE
Allow unique materials

### DIFF
--- a/Assets/Editor/Test/Content/TestMaterial.cs
+++ b/Assets/Editor/Test/Content/TestMaterial.cs
@@ -51,5 +51,10 @@ namespace CreateAR.EnkluPlayer.Test.Scripting
         {
             _c4s[param] = value;
         }
+
+        public void Teardown()
+        {
+            
+        }
     }
 }

--- a/Assets/Editor/Test/Content/TestRenderer.cs
+++ b/Assets/Editor/Test/Content/TestRenderer.cs
@@ -5,6 +5,7 @@ namespace CreateAR.EnkluPlayer.Test.Scripting
     public class TestRenderer : IRenderer
     {
         public IMaterial SharedMaterial { get; set; }
+        public IMaterial Material { get; set; }
 
         public TestRenderer(TestMaterial material)
         {

--- a/Assets/Source/Player/Scripting/IRenderer.cs
+++ b/Assets/Source/Player/Scripting/IRenderer.cs
@@ -9,5 +9,10 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// The shared material used.
         /// </summary>
         IMaterial SharedMaterial { get; set; }
+        
+        /// <summary>
+        /// The unique material used. Using this will break shared usages!!
+        /// </summary>
+        IMaterial Material { get; set; }
     }
 }

--- a/Assets/Source/Player/Scripting/Interface/App/ElementJsCache.cs
+++ b/Assets/Source/Player/Scripting/Interface/App/ElementJsCache.cs
@@ -62,7 +62,7 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// Cleans up the cache entry for an Element when it gets destroyed.
         /// </summary>
         /// <param name="element"></param>
-        public void Element_OnDestroy(Element element)
+        private void Element_OnDestroy(Element element)
         {
             ElementJs el;
             if (_elementMap.TryGetValue(element, out el))

--- a/Assets/Source/Player/Scripting/Interface/App/ElementJsCache.cs
+++ b/Assets/Source/Player/Scripting/Interface/App/ElementJsCache.cs
@@ -42,17 +42,34 @@ namespace CreateAR.EnkluPlayer.Scripting
 
             el = _elementMap[element] = _elements.Instance(this, element);
 
+            element.OnDestroyed += Element_OnDestroy;
+
             return el;
         }
 
         /// <inheritdoc />
         public void Clear()
         {
-            foreach (var el in _elementMap.Values)
+            foreach (var kvp in _elementMap)
             {
-                el.Cleanup();
+                kvp.Key.OnDestroyed -= Element_OnDestroy;
+                kvp.Value.Cleanup();
             }
             _elementMap.Clear();
+        }
+
+        /// <summary>
+        /// Cleans up the cache entry for an Element when it gets destroyed.
+        /// </summary>
+        /// <param name="element"></param>
+        public void Element_OnDestroy(Element element)
+        {
+            ElementJs el;
+            if (_elementMap.TryGetValue(element, out el))
+            {
+                _elementMap.Remove(element);
+                el.Cleanup();
+            }
         }
     }
 }

--- a/Assets/Source/Player/Scripting/Interface/Elements/ContentWidgetJs.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/ContentWidgetJs.cs
@@ -56,6 +56,8 @@ namespace CreateAR.EnkluPlayer.Scripting
             base.Cleanup();
 
             _contentWidget.OnLoaded.Remove(CacheComponents);
+            
+            TeardownComponents();
         }
 
         /// <summary>
@@ -63,12 +65,9 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// </summary>
         private void CacheComponents(ContentWidget contentWidget)
         {
-            // Animator
-            if (animator != null)
-            {
-                animator.Teardown();
-            }
+            TeardownComponents();
             
+            // Animator
             var unityAnimator = contentWidget.GetComponent<Animator>();
             if (unityAnimator != null) 
             {
@@ -82,11 +81,6 @@ namespace CreateAR.EnkluPlayer.Scripting
             }
             
             // Material
-            if (material != null)
-            {
-                material.Teardown();
-            }
-            
             var unityRenderer = contentWidget.GetComponent<Renderer>();
             if (unityRenderer != null && unityRenderer.sharedMaterial != null)
             {
@@ -100,11 +94,6 @@ namespace CreateAR.EnkluPlayer.Scripting
             }
 
             // Audio
-            if (audio != null)
-            {
-                audio.Teardown();
-            }
-            
             var unityAudioSource = contentWidget.GetComponent<AudioSource>();
             if (unityAudioSource != null)
             {
@@ -115,6 +104,27 @@ namespace CreateAR.EnkluPlayer.Scripting
             else
             {
                 audio = null;
+            }
+        }
+
+        /// <summary>
+        /// Calls Teardown on any existing components.
+        /// </summary>
+        private void TeardownComponents()
+        {
+            if (animator != null)
+            {
+                animator.Teardown();
+            }
+            
+            if (material != null)
+            {
+                material.Teardown();
+            }
+            
+            if (audio != null)
+            {
+                audio.Teardown();
             }
         }
     }

--- a/Assets/Source/Player/Scripting/Interface/Elements/MaterialJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/MaterialJsApi.cs
@@ -100,6 +100,9 @@ namespace CreateAR.EnkluPlayer.Scripting
             _setup = false;
         }
 
+        /// <summary>
+        /// Breaks the underlying shared material link, causing this material to be unique.
+        /// </summary>
         public void makeUnique()
         {
             var mat = _renderer.Material;

--- a/Assets/Source/Player/Scripting/Interface/Elements/MaterialJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/MaterialJsApi.cs
@@ -53,6 +53,7 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// <summary>
         /// Subscribes to schema.
         /// </summary>
+        [DenyJsAccess]
         public void Setup()
         {
             if (_setup)
@@ -68,6 +69,7 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// <summary>
         /// Unsubscribes from schema.
         /// </summary>
+        [DenyJsAccess]
         public void Teardown()
         {
             if (!_setup)
@@ -96,6 +98,11 @@ namespace CreateAR.EnkluPlayer.Scripting
             }
 
             _setup = false;
+        }
+
+        public void makeUnique()
+        {
+            var mat = _renderer.Material;
         }
 
         /// <summary>

--- a/Assets/Source/Player/Scripting/Interface/IMaterial.cs
+++ b/Assets/Source/Player/Scripting/Interface/IMaterial.cs
@@ -60,5 +60,10 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// <param name="param"></param>
         /// <param name="value"></param>
         void SetCol4(string param, Col4 value);
+
+        /// <summary>
+        /// Cleanup.
+        /// </summary>
+        void Teardown();
     }
 }

--- a/Assets/Source/Player/Scripting/Interface/UnityMaterial.cs
+++ b/Assets/Source/Player/Scripting/Interface/UnityMaterial.cs
@@ -78,6 +78,7 @@ namespace CreateAR.EnkluPlayer.Scripting
             Material.SetVector(param, value.ToColor());
         }
 
+        /// <inheritdoc />
         public void Teardown()
         {
             if (!_shared)

--- a/Assets/Source/Player/Scripting/Interface/UnityMaterial.cs
+++ b/Assets/Source/Player/Scripting/Interface/UnityMaterial.cs
@@ -8,6 +8,11 @@ namespace CreateAR.EnkluPlayer.Scripting
     public class UnityMaterial : IMaterial
     {
         /// <summary>
+        /// Whether the backing material is shared or not.
+        /// </summary>
+        private bool _shared;
+        
+        /// <summary>
         /// Backing material.
         /// </summary>
         public Material Material { get; private set; }
@@ -16,9 +21,11 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// Constructor.
         /// </summary>
         /// <param name="material"></param>
-        public UnityMaterial(Material material)
+        /// <param name="shared"></param>
+        public UnityMaterial(Material material, bool shared)
         {
             Material = material;
+            _shared = shared;
         }
         
         /// <inheritdoc />
@@ -69,6 +76,14 @@ namespace CreateAR.EnkluPlayer.Scripting
         public void SetCol4(string param, Col4 value)
         {
             Material.SetVector(param, value.ToColor());
+        }
+
+        public void Teardown()
+        {
+            if (!_shared)
+            {
+                Object.Destroy(Material);
+            }
         }
     }
 }

--- a/Assets/Source/Player/Scripting/Interface/UnityRenderer.cs
+++ b/Assets/Source/Player/Scripting/Interface/UnityRenderer.cs
@@ -18,6 +18,11 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// </summary>
         private IMaterial _material;
 
+        /// <summary>
+        /// Whether the cached material is shared.
+        /// </summary>
+        private bool _shared;
+
         /// <inheritdoc />
         public IMaterial SharedMaterial
         {
@@ -34,6 +39,32 @@ namespace CreateAR.EnkluPlayer.Scripting
                 _renderer.sharedMaterial = unityMat.Material;
             }
         }
+        
+        /// <inheritdoc />
+        public IMaterial Material
+        {
+            get 
+            {
+                if (_shared)
+                {
+                    _shared = false;
+                    _material = new UnityMaterial(_renderer.material, _shared);
+                }
+
+                return _material;
+            }
+            set
+            {
+                var unityMat = value as UnityMaterial;
+                if (unityMat == null)
+                {
+                    throw new Exception("Trying to use non UnityMaterial with UnityRenderer");
+                }
+
+                _material = value;
+                _renderer.material = unityMat.Material;
+            }
+        }
 
         /// <summary>
         /// Constructor.
@@ -42,7 +73,18 @@ namespace CreateAR.EnkluPlayer.Scripting
         public UnityRenderer(Renderer renderer)
         {
             _renderer = renderer;
-            _material = new UnityMaterial(renderer.sharedMaterial);
+            _shared = true;
+            _material = new UnityMaterial(renderer.sharedMaterial, _shared);
+        }
+
+        /// <summary>
+        /// Creates a UnityMaterial around a Material instance.
+        /// </summary>
+        /// <param name="material"></param>
+        /// <returns></returns>
+        private UnityMaterial CreateMaterial(Material material)
+        {
+            return new UnityMaterial(_renderer.material, _shared);
         }
     }
 }


### PR DESCRIPTION
Exposes a new `makeUnique()` call to the material scripting API, allowing a material to break its shared linkage.

The underlying `IRenderer`/`IMaterial` continue to share Unity's vocabulary and usage pattern of `sharedMaterial` and `material`. When we add more custom functionality, it'd be good to revisit this and explore having just one material field and functions to break/join shared usages. At least, IMO, the Unity syntax for it kinda sucks.