### PR TITLE
Video Capture Bugs

### DIFF
--- a/Assets/Source/Application/States/Play/Hmd/HoloLensVideoManager.cs
+++ b/Assets/Source/Application/States/Play/Hmd/HoloLensVideoManager.cs
@@ -99,11 +99,14 @@ namespace CreateAR.EnkluPlayer
             {
                 // Find saves already on the device. If they're there, it means they failed previously.
                 var root = Path.Combine(UnityEngine.Application.persistentDataPath, _snapConfig.VideoFolder);
-                FindExistingUploads(root, _failedUploads);
-
-                if (_failedUploads.Count > 0)
+                if (Directory.Exists(root))
                 {
-                    Log.Info(this, "Previously failed uploads: {0}", _failedUploads.Count);
+                    FindExistingUploads(root, _failedUploads);
+
+                    if (_failedUploads.Count > 0)
+                    {
+                        Log.Info(this, "Previously failed uploads: {0}", _failedUploads.Count);
+                    }
                 }
             }
             
@@ -206,7 +209,7 @@ namespace CreateAR.EnkluPlayer
             
             try 
             {
-                var filename = filepath.Substring(filepath.LastIndexOf("\\" + 1));
+                var filename = filepath.Substring(filepath.LastIndexOf("\\") + 1);
                 var url = _http.Urls.Url(string.Format("/org/{0}/snap/gamma", _orgId));
                     
                 Log.Info(this, "Uploading {0} to {1}", filepath, url);

--- a/Assets/Source/Application/States/Play/HoloLensImageManager.cs
+++ b/Assets/Source/Application/States/Play/HoloLensImageManager.cs
@@ -99,11 +99,14 @@ namespace CreateAR.EnkluPlayer
             {
                 // Find saves already on the device. If they're there, it means they failed previously.
                 var root = Path.Combine(UnityEngine.Application.persistentDataPath, _snapConfig.ImageFolder);
-                FindExistingUploads(root, _failedUploads);
-
-                if (_failedUploads.Count > 0)
+                if (Directory.Exists(root))
                 {
-                    Log.Info(this, "Previously failed uploads: {0}", _failedUploads.Count);
+                    FindExistingUploads(root, _failedUploads);
+
+                    if (_failedUploads.Count > 0)
+                    {
+                        Log.Info(this, "Previously failed uploads: {0}", _failedUploads.Count);
+                    }
                 }
             }
             
@@ -206,7 +209,7 @@ namespace CreateAR.EnkluPlayer
             
             try
             {
-                var filename = filepath.Substring(filepath.LastIndexOf("\\" + 1));
+                var filename = filepath.Substring(filepath.LastIndexOf("\\") + 1);
                 var url = _http.Urls.Url(string.Format("/org/{0}/snap/gamma", _orgId));
                     
                 Log.Info(this, "Uploading {0} to {1}", filepath, url);

--- a/Assets/Source/Player/Scripting/Interop/SnapUploader.cs
+++ b/Assets/Source/Player/Scripting/Interop/SnapUploader.cs
@@ -21,11 +21,20 @@ namespace Source.Player.Scripting.Interop
             _videoManager = videoManager;
             _imageManager = imageManager;
         }
+        
+        /// <summary>
+        /// Enables the uploaders for processing.
+        /// TODO: Remove when EK-1124 is resolved.
+        /// </summary>
+        public void enableUploads(string tag)
+        {
+            enableUploads(tag, false);
+        }
 
         /// <summary>
         /// Enables the uploaders for processing.
         /// </summary>
-        public void enableUploads(string tag, bool uploadExisting = false)
+        public void enableUploads(string tag, bool uploadExisting)
         {
             _videoManager.EnableUploads(tag, uploadExisting);
             _imageManager.EnableUploads(tag, uploadExisting);


### PR DESCRIPTION
Fixes a few bugs:
- First time case, when the device doesn't have an `images` or `video` folder. Checks for directory existence first now.
- Properly gets the filename from a path string.
- Minor scripting api change to get around method overloading