### PR TITLE
Allow experiences to define custom funtionality for locating prompts

### DIFF
--- a/Assets/Source/Application/Injection/EnkluPlayerModule.cs
+++ b/Assets/Source/Application/Injection/EnkluPlayerModule.cs
@@ -724,8 +724,9 @@ namespace CreateAR.EnkluPlayer
                     binder.GetInstance<IDeviceMetaProvider>(),
                     binder.GetInstance<IImageCapture>(),
                     binder.GetInstance<IVideoCapture>(),
-                    binder.GetInstance<AwsPingController>(),
                     binder.GetInstance<IMessageRouter>(),
+                    binder.GetInstance<IAppSceneManager>(),
+                    binder.GetInstance<AwsPingController>(),
                     binder.GetInstance<ApiController>(),
                     binder.GetInstance<ApplicationConfig>());
 

--- a/Assets/Source/Application/States/Play/Hmd/PrimaryAnchorManager.cs
+++ b/Assets/Source/Application/States/Play/Hmd/PrimaryAnchorManager.cs
@@ -820,7 +820,7 @@ Errors: {3} / {0}",
             
             if (unlocated + errors == _anchors.Count)
             {
-                _bypassBtn.Schema.Set("visible", !DisableBypass);
+                _bypassBtn.Schema.Set("visible", !_disableBypassProp.Value);
             }
         }
 
@@ -838,7 +838,7 @@ Errors: {3} / {0}",
             _cpnLocating.Label = _locatingMessageProp.Value;
 
             _rootUI.Schema.Set("visible", true);
-            _bypassBtn.Schema.Set("visible", !DisableBypass);
+            _bypassBtn.Schema.Set("visible", !_disableBypassProp.Value);
         }
 
         /// <summary>

--- a/Assets/Source/Application/States/Play/Hmd/PrimaryAnchorManager.cs
+++ b/Assets/Source/Application/States/Play/Hmd/PrimaryAnchorManager.cs
@@ -42,6 +42,8 @@ namespace CreateAR.EnkluPlayer
         public const string PROP_TAG_KEY = "tag";
         public const string PROP_TAG_VALUE = "primary";
         public const string PROP_ENABLED_KEY = "worldanchor.enabled";
+        public const string PROP_LOCATING_MESSAGE_KEY = "anchoring.locatingMessage";
+        public const string PROP_DISABLE_BYPASS_KEY = "anchoring.disableBypass";
 
         /// <summary>
         /// True iff all anchors are ready to go.
@@ -161,7 +163,12 @@ namespace CreateAR.EnkluPlayer
         /// <summary>
         /// Caption on UI.
         /// </summary>
-        private TextWidget _cpn;
+        private TextWidget _cpnProgress;
+        
+        /// <summary>
+        /// Caption on UI.
+        /// </summary>
+        private TextWidget _cpnLocating;
 
         /// <summary>
         /// True iff world anchors are enabled.
@@ -193,6 +200,16 @@ namespace CreateAR.EnkluPlayer
         /// </summary>
         private int _pollUnlocated;
         private int _pollLocated;
+
+        /// <summary>
+        /// A custom locating message.
+        /// </summary>
+        private ElementSchemaProp<string> _locatingMessageProp;
+
+        /// <summary>
+        /// Whether the bypass button should be disabled or not.
+        /// </summary>
+        private ElementSchemaProp<bool> _disableBypassProp;
         
         /// <summary>
         /// Read only collection of currently tracked anchors.
@@ -297,6 +314,12 @@ namespace CreateAR.EnkluPlayer
 
             if (_anchorsEnabledProp.Value)
             {
+                _locatingMessageProp = root.Schema.GetOwn(PROP_LOCATING_MESSAGE_KEY, "Attempting to locate content.\nPlease walk around space.");
+                _disableBypassProp = root.Schema.GetOwn(PROP_DISABLE_BYPASS_KEY, false);
+
+                _locatingMessageProp.OnChanged += (prop, prev, next) => UpdateLocatingUI();
+                _disableBypassProp.OnChanged += (prop, prev, next) => UpdateLocatingUI();
+                
                 SetupAnchors();
             }
             else
@@ -596,11 +619,13 @@ namespace CreateAR.EnkluPlayer
         {
             _rootUI = _elements.Element(@"
 <?Vine>
-<Float>
-    <Caption id='cpn' position=(0, 0.25, 0) label='Locating anchors.' width=1400.0 alignment='MidCenter' fontSize=100 />
+<Float focus.visible=false>
+    <Caption id='cpn-progress' position=(0, 0.25, 0) label='Locating anchors.' width=1400.0 alignment='MidCenter' fontSize=100 />
+    <Caption visible=false id='cpn-locating' position=(0, 0.25, 0) label='Locating anchors.' width=1400.0 alignment='MidCenter' fontSize=100 />
     <Button id='btn' position=(0, -0.1, 0) label='Bypass' visible=false />
 </Float>");
-            _cpn = _rootUI.FindOne<TextWidget>("..cpn");
+            _cpnProgress = _rootUI.FindOne<TextWidget>("..cpn-progress");
+            _cpnLocating = _rootUI.FindOne<TextWidget>("..cpn-locating");
             _bypassBtn = _rootUI.FindOne<ButtonWidget>("..btn");
             _bypassBtn.OnActivated += _ => BypassAnchorRequirement();
         }
@@ -750,41 +775,70 @@ namespace CreateAR.EnkluPlayer
         /// </summary>
         private void UpdateStatusUI(int errors, int downloading, int importing, int unlocated, int located)
         {
-            if (null == _cpn || null == _rootUI)
+            if (null == _cpnProgress || null == _rootUI)
             {
                 return;
             }
 
             if (downloading + importing + errors > 0)
             {
-                _cpn.Label = string.Format(
-@"Please wait...
-
-Downloading: {1} / {0}
-Importing: {2} / {0}
-Errors: {3} / {0}",
-                    _anchors.Count,
-                    downloading,
-                    importing,
-                    errors);
-
-                _rootUI.Schema.Set("visible", true);
+                _cpnProgress.LocalVisible = true;
+                _cpnLocating.LocalVisible = false;
+                
+                UpdateProgressUI(errors, downloading, importing, unlocated, located);
             }
             else if (0 == located)
             {
-                _cpn.Label = "Attempting to locate content.\nPlease walk around space.";
-
-                _rootUI.Schema.Set("visible", true);
+                _cpnLocating.LocalVisible = true;
+                _cpnProgress.LocalVisible = false;
+                
+                UpdateLocatingUI();
             }
             else
             {
                 _rootUI.Schema.Set("visible", false);
             }
+        }
+
+        /// <summary>
+        /// Updates the progress UI.
+        /// </summary>
+        private void UpdateProgressUI(int errors, int downloading, int importing, int unlocated, int located)
+        {
+            _cpnProgress.Label = string.Format(
+                @"Please wait...
+
+Downloading: {1} / {0}
+Importing: {2} / {0}
+Errors: {3} / {0}",
+                _anchors.Count,
+                downloading,
+                importing,
+                errors);
+
+            _rootUI.Schema.Set("visible", true);
             
             if (unlocated + errors == _anchors.Count)
             {
-                _bypassBtn.Schema.Set("visible", true);
+                _bypassBtn.Schema.Set("visible", !DisableBypass);
             }
+        }
+
+        /// <summary>
+        /// Updates the locating UI.
+        /// </summary>
+        private void UpdateLocatingUI()
+        {
+            if (_cpnLocating == null)
+            {
+                // Safety in case custom messages are set before the vine has been built.
+                return;
+            }
+
+            _cpnLocating.Label = _locatingMessageProp.Value;
+
+            _rootUI.Schema.Set("visible", true);
+            _bypassBtn.Schema.Set("visible", !DisableBypass);
         }
 
         /// <summary>
@@ -862,7 +916,7 @@ Errors: {3} / {0}",
             {
                 _rootUI.Destroy();
                 _rootUI = null;
-                _cpn = null;
+                _cpnProgress = null;
             }
         }
 

--- a/Assets/Source/Player/Scripting/Interface/App/SystemJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/App/SystemJsApi.cs
@@ -82,6 +82,12 @@ namespace CreateAR.EnkluPlayer.Scripting
             get
             {
                 var sceneId = _sceneManager.All.FirstOrDefault();
+                if (string.IsNullOrEmpty(sceneId))
+                {
+                    Log.Error(this, "No scene found.");
+                    return string.Empty;
+                }
+                
                 var root = _sceneManager.Root(sceneId);
                 var schema = root.Schema.Get<string>(PrimaryAnchorManager.PROP_LOCATING_MESSAGE_KEY);
                 return schema.Value;
@@ -89,6 +95,12 @@ namespace CreateAR.EnkluPlayer.Scripting
             set 
             { 
                 var sceneId = _sceneManager.All.FirstOrDefault();
+                if (string.IsNullOrEmpty(sceneId))
+                {
+                    Log.Error(this, "No scene found.");
+                    return;
+                }
+                
                 var root = _sceneManager.Root(sceneId);
                 var schema = root.Schema.Get<string>(PrimaryAnchorManager.PROP_LOCATING_MESSAGE_KEY);
                 schema.Value = value;
@@ -103,6 +115,12 @@ namespace CreateAR.EnkluPlayer.Scripting
             get
             {
                 var sceneId = _sceneManager.All.FirstOrDefault();
+                if (string.IsNullOrEmpty(sceneId))
+                {
+                    Log.Error(this, "No scene found.");
+                    return false;
+                }
+                
                 var root = _sceneManager.Root(sceneId);
                 var schema = root.Schema.Get<bool>(PrimaryAnchorManager.PROP_DISABLE_BYPASS_KEY);
                 return schema.Value;
@@ -110,6 +128,12 @@ namespace CreateAR.EnkluPlayer.Scripting
             set 
             { 
                 var sceneId = _sceneManager.All.FirstOrDefault();
+                if (string.IsNullOrEmpty(sceneId))
+                {
+                    Log.Error(this, "No scene found.");
+                    return;
+                }
+                
                 var root = _sceneManager.Root(sceneId);
                 var schema = root.Schema.Get<bool>(PrimaryAnchorManager.PROP_DISABLE_BYPASS_KEY);
                 schema.Value = value;

--- a/Assets/Source/Player/Scripting/Interface/App/SystemJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/App/SystemJsApi.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using CreateAR.Commons.Unity.Http;
 using CreateAR.Commons.Unity.Logging;
 using CreateAR.Commons.Unity.Messaging;
@@ -28,8 +29,9 @@ namespace CreateAR.EnkluPlayer.Scripting
             IDeviceMetaProvider deviceMetaProvider,
             IImageCapture imageCapture,
             IVideoCapture videoCapture,
-            AwsPingController awsPingController,
             IMessageRouter msgRouter,
+            IAppSceneManager sceneManager,
+            AwsPingController awsPingController,
             ApiController apiController,
             ApplicationConfig config)
         {
@@ -42,9 +44,15 @@ namespace CreateAR.EnkluPlayer.Scripting
             Instance.experiences = new ExperienceJsApi(msgRouter, apiController, config);
             Instance.network = new NetworkJsApi(awsPingController);
             Instance.debugRendering = new DebugRenderingJsApi();
+            Instance._sceneManager = sceneManager;
 
             _initialized = true;
         }
+
+        /// <summary>
+        /// For modifying the root's schema.
+        /// </summary>
+        private IAppSceneManager _sceneManager;
 
         /// <summary>
         /// Provides details about the device.
@@ -65,6 +73,48 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// Provides API for debug rendering.
         /// </summary>
         public DebugRenderingJsApi debugRendering { get; private set; }
+
+        /// <summary>
+        /// Allows a custom message to display when the device is locating anchors.
+        /// </summary>
+        public string locatingMessage
+        {
+            get
+            {
+                var sceneId = _sceneManager.All.FirstOrDefault();
+                var root = _sceneManager.Root(sceneId);
+                var schema = root.Schema.Get<string>(PrimaryAnchorManager.PROP_LOCATING_MESSAGE_KEY);
+                return schema.Value;
+            }
+            set 
+            { 
+                var sceneId = _sceneManager.All.FirstOrDefault();
+                var root = _sceneManager.Root(sceneId);
+                var schema = root.Schema.Get<string>(PrimaryAnchorManager.PROP_LOCATING_MESSAGE_KEY);
+                schema.Value = value;
+            }
+        }
+
+        /// <summary>
+        /// Allows anchor bypassing to be disabled.
+        /// </summary>
+        public bool disableAnchorBypass
+        {
+            get
+            {
+                var sceneId = _sceneManager.All.FirstOrDefault();
+                var root = _sceneManager.Root(sceneId);
+                var schema = root.Schema.Get<bool>(PrimaryAnchorManager.PROP_DISABLE_BYPASS_KEY);
+                return schema.Value;
+            }
+            set 
+            { 
+                var sceneId = _sceneManager.All.FirstOrDefault();
+                var root = _sceneManager.Root(sceneId);
+                var schema = root.Schema.Get<bool>(PrimaryAnchorManager.PROP_DISABLE_BYPASS_KEY);
+                schema.Value = value;
+            }
+        }
 
         /// <summary>
         /// Recenters tracking.


### PR DESCRIPTION
This allows a custom message to be set for locating anchors, as well as whether the anchor bypass button is disabled or not.

The accessors for the scripting API are a bit gross, but it avoids caching the root and dealing with listening for experience loading and whatnot, which seems too heavy for a js api to deal with.