### PR TITLE
Hackishly disable rendering the asset bounds

### DIFF
--- a/Assets/Source/Player/IUX/Content/ModelLoadingOutline.cs
+++ b/Assets/Source/Player/IUX/Content/ModelLoadingOutline.cs
@@ -127,7 +127,10 @@ namespace CreateAR.EnkluPlayer
         private void OnRenderObject()
         {
             // TODO: Remove when the web editor bug that always displays outlines is sorted out
-            if (!_isError) return;
+            if (!_isError)
+            {
+                return;
+            }
         
             CreateLineMaterial();
 

--- a/Assets/Source/Player/IUX/Content/ModelLoadingOutline.cs
+++ b/Assets/Source/Player/IUX/Content/ModelLoadingOutline.cs
@@ -126,6 +126,9 @@ namespace CreateAR.EnkluPlayer
         /// </summary>
         private void OnRenderObject()
         {
+            // TODO: Remove when the web editor bug that always displays outlines is sorted out
+            if (!_isError) return;
+        
             CreateLineMaterial();
 
             _lineMaterial.SetPass(0);


### PR DESCRIPTION
I tried to look into the root cause for a bit, turns out to be trickier to track down than hoped. So for now - just disabling the model outlines entirely unless there's an error.