### PR TITLE
Global system.resume message.

### DIFF
--- a/Assets/Source/Player/Scripting/Interface/App/SystemJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/App/SystemJsApi.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using CreateAR.Commons.Unity.Http;
 using CreateAR.Commons.Unity.Logging;
 using CreateAR.Commons.Unity.Messaging;
 using CreateAR.Trellis.Messages;

--- a/Assets/Source/Player/Scripting/Interface/MessagingJsInterface.cs
+++ b/Assets/Source/Player/Scripting/Interface/MessagingJsInterface.cs
@@ -64,6 +64,10 @@ namespace CreateAR.EnkluPlayer.Scripting
         public MessagingJsInterface(JsMessageRouter messages)
         {
             _messages = messages;
+
+            _messages.Subscribe(
+                MessageTypes.APPLICATION_RESUME,
+                _ => dispatch("system.resume"));
         }
 
         /// <summary>


### PR DESCRIPTION
Messaging dispatches a resume event. Since suspend is useless, I figured I wouldn't even add it.