### PR TITLE
Bind APPLICATION_RESUME message to the IMessageRouter instance

### DIFF
--- a/Assets/Editor/Test/Scripting/MessagesJsApi_Tests.cs
+++ b/Assets/Editor/Test/Scripting/MessagesJsApi_Tests.cs
@@ -2,6 +2,7 @@
 using Jint.Native;
 using NUnit.Framework;
 using System;
+using CreateAR.Commons.Unity.Messaging;
 using CreateAR.EnkluPlayer.Scripting;
 using UnityEngine;
 
@@ -18,7 +19,7 @@ namespace CreateAR.EnkluPlayer.Test.Scripting
             _engine = JintUtil.NewEngine(false);
 
             _engine.SetValue("require", new Func<string, JsValue>(
-                value => JsValue.FromObject(_engine, new MessagingJsInterface(new JsMessageRouter()))
+                value => JsValue.FromObject(_engine, new MessagingJsInterface(new MessageRouter(), new JsMessageRouter()))
             ));
         }
 

--- a/Assets/Source/Player/Scripting/Interface/MessagingJsInterface.cs
+++ b/Assets/Source/Player/Scripting/Interface/MessagingJsInterface.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using CreateAR.Commons.Unity.Logging;
+using CreateAR.Commons.Unity.Messaging;
 using Jint;
 using Jint.Native;
 using Jint.Runtime;
@@ -61,11 +62,11 @@ namespace CreateAR.EnkluPlayer.Scripting
         /// <summary>
         /// Constructor.
         /// </summary>
-        public MessagingJsInterface(JsMessageRouter messages)
+        public MessagingJsInterface(IMessageRouter systemRouter, JsMessageRouter jsRouter)
         {
-            _messages = messages;
+            _messages = jsRouter;
 
-            _messages.Subscribe(
+            systemRouter.Subscribe(
                 MessageTypes.APPLICATION_RESUME,
                 _ => dispatch("system.resume"));
         }
@@ -116,7 +117,6 @@ namespace CreateAR.EnkluPlayer.Scripting
         public void dispatch(string eventType)
         {
             dispatch(eventType, Void.Instance);
-            
         }
 
         /// <summary>


### PR DESCRIPTION
Small bugfix. The `MessagingJsInterface` was listening to its own message router for the APPLICATION_RESUME message.