### PR TITLE
Add transform.forward to IElementTransformJsApi

### DIFF
--- a/Assets/Source/Player/Scripting/Interface/Elements/ElementTransformJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/ElementTransformJsApi.cs
@@ -57,9 +57,7 @@ namespace CreateAR.EnkluPlayer.Scripting
             set { _scaleProp.Value = value; }
         }
 
-        /// <summary>
-        /// Forward.
-        /// </summary>
+        /// <inheritdoc />
         public Vec3 forward
         {
             get { return Quat.Mult(rotation, Vec3.Forward); }

--- a/Assets/Source/Player/Scripting/Interface/Elements/IElementTransformJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/Elements/IElementTransformJsApi.cs
@@ -24,6 +24,11 @@ namespace CreateAR.EnkluPlayer.Scripting
         Vec3 scale { get; set; }
 
         /// <summary>
+        /// Forward.
+        /// </summary>
+        Vec3 forward { get; }
+        
+        /// <summary>
         /// Returns the position of this transform relative to another entity. This value should not
         /// be cached as elements aren't guaranteed to sit under the same world anchor.
         ///

--- a/Assets/Source/Player/Scripting/Interface/UnityTransformJsApi.cs
+++ b/Assets/Source/Player/Scripting/Interface/UnityTransformJsApi.cs
@@ -82,6 +82,12 @@ namespace CreateAR.EnkluPlayer.Scripting
         }
 
         /// <inheritdoc />
+        public Vec3 forward
+        {
+            get { return UnityTransform.forward.ToVec(); }
+        }
+
+        /// <inheritdoc />
         public Vec3 worldPosition
         {
             get { return UnityTransform.position.ToVec(); }


### PR DESCRIPTION
Turns out `ElementTransformJsApi` already had it?!?!?!?! Bringing it up to the interface, adding it for the camera as well.