### PR TITLE
Multiplayer Reconcile

### DIFF
--- a/Assets/Source/Application/States/Play/Multiplayer/MyceliumMultiplayerController.cs
+++ b/Assets/Source/Application/States/Play/Multiplayer/MyceliumMultiplayerController.cs
@@ -303,7 +303,7 @@ namespace CreateAR.EnkluPlayer
                 var res = (CreateElementResponse) obj;
                 if (res.Success)
                 {
-                    // send to scene handler
+                    // forward to scene handler for tracking
                     var newElement = _sceneHandler.OnCreated(new CreateElementEvent
                     {
                         Element = element,

--- a/Assets/Source/Application/States/Play/Multiplayer/MyceliumMultiplayerController.cs
+++ b/Assets/Source/Application/States/Play/Multiplayer/MyceliumMultiplayerController.cs
@@ -180,7 +180,7 @@ namespace CreateAR.EnkluPlayer
             _sceneHandler = new SceneEventHandler(
                 _elements,
                 elementFactory,
-                new ScenePatcher(scenes, patcherFactory));
+                new ScenePatcher(elements, scenes, patcherFactory));
             _synchronizer = new PropSynchronizer(msg =>
             {
                 Verbose("Sending {0}.", msg);

--- a/Assets/Source/Application/States/Play/Multiplayer/SceneEventHandler.cs
+++ b/Assets/Source/Application/States/Play/Multiplayer/SceneEventHandler.cs
@@ -161,7 +161,6 @@ namespace CreateAR.EnkluPlayer
             _scenePatcher.Apply(actions);
 
             // remove tracked creates that have no associated create diff
-            // TODO: we are missing elements that WE created
             for (var i = _trackedCreates.Count - 1; i >= 0; i--)
             {
                 var element = _trackedCreates[i];
@@ -195,7 +194,7 @@ namespace CreateAR.EnkluPlayer
         
         /// <summary>
         /// Processes a <c>CreateElementEvent</c>. These events are received when
-        /// someone else creates an element.
+        /// anyone creates an element, including this client.
         /// </summary>
         /// <param name="evt">The event.</param>
         public Element OnCreated(CreateElementEvent evt)

--- a/Assets/Source/Application/States/Play/Multiplayer/SceneEventHandler.cs
+++ b/Assets/Source/Application/States/Play/Multiplayer/SceneEventHandler.cs
@@ -113,7 +113,8 @@ namespace CreateAR.EnkluPlayer
         }
 
         /// <summary>
-        /// Retrieves the element id from the hash.
+        /// Retrieves the element id from the hash. This is much more efficient
+        /// than using the element map function.
         /// </summary>
         /// <param name="hash">The hash.</param>
         /// <returns></returns>
@@ -128,7 +129,8 @@ namespace CreateAR.EnkluPlayer
         }
 
         /// <summary>
-        /// Retrieves a prop name from hash.
+        /// Retrieves a prop name from hash. This is much more efficient than
+        /// using the element map function.
         /// </summary>
         /// <param name="hash">The hash.</param>
         /// <returns></returns>
@@ -143,7 +145,10 @@ namespace CreateAR.EnkluPlayer
         }
         
         /// <summary>
-        /// Applies a diff to the scene.
+        /// Applies a diff to the scene. Diffs are received any time we connect
+        /// or reconnect. These are _absolute_ diffs, meaning that they contain
+        /// all changes between the current state of the experience and the
+        /// static data definition.
         /// </summary>
         /// <param name="evt">The diff event.</param>
         public void OnDiff(SceneDiffEvent evt)
@@ -189,7 +194,8 @@ namespace CreateAR.EnkluPlayer
         }
         
         /// <summary>
-        /// Processes a <c>CreateElementEvent</c>.
+        /// Processes a <c>CreateElementEvent</c>. These events are received when
+        /// someone else creates an element.
         /// </summary>
         /// <param name="evt">The event.</param>
         public Element OnCreated(CreateElementEvent evt)
@@ -233,7 +239,8 @@ namespace CreateAR.EnkluPlayer
         }
         
         /// <summary>
-        /// Processes a <c>DeleteElementEvent</c>.
+        /// Processes a <c>DeleteElementEvent</c>. These are received any time
+        /// another user deletes an element.
         /// </summary>
         /// <param name="evt">The event.</param>
         public void OnDeleted(DeleteElementEvent evt)
@@ -252,7 +259,8 @@ namespace CreateAR.EnkluPlayer
         }
 
         /// <summary>
-        /// Processes an UpdateElementEvent.
+        /// Processes an UpdateElementEvent. These are received any time another
+        /// user updates an element.
         /// </summary>
         /// <typeparam name="T">The type of event.</typeparam>
         /// <param name="evt">The event.</param>

--- a/Assets/Source/Application/States/Play/Multiplayer/ScenePatcher.cs
+++ b/Assets/Source/Application/States/Play/Multiplayer/ScenePatcher.cs
@@ -15,6 +15,7 @@ namespace CreateAR.EnkluPlayer
         /// </summary>
         private readonly IAppSceneManager _scenes;
         private readonly IElementActionStrategyFactory _patcherFactory;
+        private readonly IElementManager _elements;
 
         private Element _root;
         private IElementActionStrategy _patcher;
@@ -22,8 +23,12 @@ namespace CreateAR.EnkluPlayer
         /// <summary>
         /// Creates a new <see cref="ScenePatcher"/> instance.
         /// </summary>
-        public ScenePatcher(IAppSceneManager scenes, IElementActionStrategyFactory patcherFactory)
+        public ScenePatcher(
+            IElementManager elements,
+            IAppSceneManager scenes,
+            IElementActionStrategyFactory patcherFactory)
         {
+            _elements = elements;
             _scenes = scenes;
             _patcherFactory = patcherFactory;
         }
@@ -62,6 +67,12 @@ namespace CreateAR.EnkluPlayer
                 {
                     case ElementActionTypes.CREATE:
                     {
+                        // ignore creates for elements we have already created
+                        if (null != _elements.ById(action.ElementId))
+                        {
+                            break;
+                        }
+
                         if (!_patcher.ApplyCreateAction(action, out error))
                         {
                             Log.Error(this,

--- a/Assets/Source/Network/Multiplayer/UwpTcpConnection.cs
+++ b/Assets/Source/Network/Multiplayer/UwpTcpConnection.cs
@@ -570,6 +570,7 @@ namespace CreateAR.EnkluPlayer
             _socket = new StreamSocket();
             _socket.Control.KeepAlive = true;
             _socket.Control.NoDelay = true;
+            _socket.Control.QualityOfService = SocketQualityOfService.LowLatency;
 
             try
             {


### PR DESCRIPTION
Improves reconcile for create/delete.

* Every time the client receives an event that an element has been created, it tracks that new element.
  * If we receive a delete event, it deletes the element and stops tracking it.
  * If instead we receive a scene diff, that means we have disconnected and reconnected. In this case, look over the scene diff.
    * If the scene diff contains a create that we are not already tracking, create the element.
    * If the scene diff contains a create that we are already tracking, ignore the create.
    * If the scene diff does not contain a create, then we know the element has been deleted while the client was offline-- delete the element.