### PR TITLE
Set default label width to 1500

### DIFF
--- a/Assets/Source/Player/IUX/Widget/TextWidget.cs
+++ b/Assets/Source/Player/IUX/Widget/TextWidget.cs
@@ -80,7 +80,7 @@ namespace CreateAR.EnkluPlayer.IUX
             _fontSizeProp = Schema.Get<int>("fontSize");
             _fontSizeProp.OnChanged += FontSize_OnChanged;
 
-            _widthProp = Schema.Get<float>("width");
+            _widthProp = Schema.GetOwn<float>("width", 1500);
             _widthProp.OnChanged += Width_OnChanged;
 
             _heightProp = Schema.Get<float>("height");


### PR DESCRIPTION
Eventually we should take a pass and look at which of these should be `GetOwn` vs `Get`, how their defaults work with the text backing, etc.... But crudely for now- Labels default to 1500!!! Which is the number I usually throw on for most labels.